### PR TITLE
Add nested list query support with hive-partitioned parquet output (v0.8.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ The package has two functional areas:
 Functions that query the live OpenAlex REST API:
 
 - `pro_query()` — builds query URLs with filters, search, entity selection, ID chunking
-- `pro_request()` — paginates through API results, writes JSONL
+- `pro_request()` — paginates through API results, writes JSONL; accepts nested lists of URLs (each nesting level becomes a subdirectory)
 - `pro_fetch()` — all-in-one: query → paginate → convert to parquet (project folder)
 - `pro_count()` — counts matching records
 - `pro_download_content()` — downloads PDFs / TEI XML from `content.openalex.org`
@@ -93,6 +93,7 @@ Each test file (`test-011`, `test-012`, `test-013`) has two sections:
 - `id_block()` — converts an OpenAlex ID to its block number (`floor(numeric_id / 10000)`)
 - `opt_select_fields()`, `opt_filter_names()` — helpers for building API queries
 - `prepare_snapshot()` — snapshot download/preparation utilities
+- `collect_leaf_queries()` — recursively flattens a nested list of URLs into `(path, url)` pairs (internal, used by `pro_request()`)
 
 ## Branching
 
@@ -105,5 +106,6 @@ Each test file (`test-011`, `test-012`, `test-013`) has two sections:
 - `project_dir` is the standard output directory parameter (consistent across `pro_fetch()`, `pro_request()`, `lookup_by_id()`)
 - OpenAlex IDs accepted in both short form (`W2741809807`) and long form (`https://openalex.org/W2741809807`)
 - The `openalex-snapshot` binary only accepts one `--dataset` per invocation; multi-dataset calls loop in R
+- Nested query lists produce hive-partitioned parquet: depth 1 → `query=<name>`, depth N → `query_lN=<name>`
 - VCR cassettes record/replay API calls; `api_key` is filtered to `<api-key>` in cassettes
 - `OPENALEXPRO_LIVE_TESTS=true` + a real API key enables live API tests in `test-900`

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openalexPro
 Title: Providing a more advanced access to OpenAlex for the power user
-Version: 0.7.0
+Version: 0.8.0
 Author: Rainer M Krug
 Maintainer: Rainer M Krug <Rainer@krugs.de>
 Description: More about what it does (maybe more than one line).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,17 @@
 # openalexPro (development)
 
+## New Features
+
+* `pro_request()`, `pro_request_jsonl()`, and `pro_request_jsonl_parquet()`
+  now accept **nested lists** of query URLs. Each nesting level is preserved
+  as a subdirectory in the output, and the parquet stage converts directory
+  depth into hive-style partition keys: depth 1 → `query=<name>`, depth 2 →
+  `query_l2=<name>`, depth 3 → `query_l3=<name>`, etc. The resulting dataset
+  is readable with `arrow::open_dataset()` and the partition columns appear
+  as regular columns. `pro_fetch()` inherits this behaviour automatically.
+  A new internal helper `collect_leaf_queries()` performs the recursive list
+  flattening.
+
 # openalexPro 0.7.0
 
 ## Breaking Changes

--- a/R/pro_request.R
+++ b/R/pro_request.R
@@ -79,29 +79,26 @@ pro_request <- function(
       future::plan(future::sequential)
     }
 
+    # Flatten nested list to leaf (URL, path) pairs
+    leaf_queries <- collect_leaf_queries(query_url)
+    leaf_urls    <- vapply(leaf_queries, `[[`, character(1), "url")
+    leaf_paths   <- lapply(leaf_queries, `[[`, "path")
+
     # Handle count_only case
     if (count_only) {
       result <- future.apply::future_lapply(
-        seq_along(query_url),
+        seq_along(leaf_queries),
         function(i) {
           pro_count(
-            query_url = query_url[[i]],
+            query_url = leaf_urls[[i]],
             api_key = api_key
           )
         },
         future.seed = TRUE
       )
 
-      # Create names for each query
-      query_names <- if (is.null(names(query_url))) {
-        paste0("query_", seq_along(query_url))
-      } else {
-        names(query_url)
-      }
-
-      # Combine results into a single data.frame with query names
       out <- do.call(rbind, result)
-      out$query <- query_names
+      out$query <- vapply(leaf_paths, paste, character(1), collapse = "/")
 
       return(out)
     }
@@ -110,7 +107,7 @@ pro_request <- function(
     if (progress) {
       cli::cli_alert_info("Fetching query counts...")
       counts <- vapply(
-        query_url,
+        leaf_urls,
         function(url) {
           pro_count(url, api_key = api_key)$count
         },
@@ -139,16 +136,17 @@ pro_request <- function(
         }
 
         result <- future.apply::future_lapply(
-          seq_along(query_url),
+          seq_along(leaf_queries),
           function(i) {
-            nm <- names(query_url)[i]
-            if (is.null(nm) || identical(nm, "")) {
-              nm <- paste0("query_", i)
+            path_parts <- leaf_paths[[i]]
+            query_output <- if (is.null(output)) {
+              NULL
+            } else {
+              do.call(file.path, c(list(output), as.list(path_parts)))
             }
-            query_output <- if (is.null(output)) NULL else file.path(output, nm)
 
             fetch_query_pages(
-              query_url = query_url[[i]],
+              query_url = leaf_urls[[i]],
               pages = pages,
               output = query_output,
               overwrite = FALSE,
@@ -408,4 +406,30 @@ fetch_query_pages <- function(
   success <- TRUE
 
   output
+}
+
+
+#' Flatten a nested query list into (path, url) leaf pairs
+#'
+#' @param x A character URL or a (possibly nested) named list of URLs.
+#' @param path_parts Character vector of name segments accumulated so far.
+#' @return A flat list of `list(path = character, url = character)` entries.
+#' @keywords internal
+#' @noRd
+collect_leaf_queries <- function(x, path_parts = character(0)) {
+  if (is.character(x)) {
+    return(list(list(path = path_parts, url = x)))
+  }
+  nms <- names(x)
+  if (is.null(nms)) {
+    nms <- paste0("query_", seq_along(x))
+  } else {
+    unnamed <- !nzchar(nms)
+    nms[unnamed] <- paste0("query_", which(unnamed))
+  }
+  result <- list()
+  for (i in seq_along(x)) {
+    result <- c(result, collect_leaf_queries(x[[i]], c(path_parts, nms[i])))
+  }
+  result
 }

--- a/R/pro_request_jsonl.R
+++ b/R/pro_request_jsonl.R
@@ -197,7 +197,11 @@ pro_request_jsonl <- function(
         gsub(pattern = ".json", replacement = "")
 
       if (has_subdirs) {
-        jsonl <- file.path(output, basename(dirname(fn)), basename(fn))
+        # Preserve full relative subdirectory path (handles arbitrary nesting depth)
+        input_depth <- length(strsplit(gsub("\\\\", "/", input_json), "/")[[1]])
+        f_parts     <- strsplit(gsub("\\\\", "/", dirname(fn)), "/")[[1]]
+        rel_parts   <- f_parts[seq(input_depth + 1L, length(f_parts))]
+        jsonl <- do.call(file.path, c(list(output), as.list(rel_parts), list(basename(fn))))
         pn <- basename(dirname(fn))
       } else {
         jsonl <- file.path(output, basename(fn))

--- a/R/pro_request_jsonl_parquet.R
+++ b/R/pro_request_jsonl_parquet.R
@@ -171,19 +171,26 @@ pro_request_jsonl_parquet <- function(
   # for some calls and long names (runneradmin) for others, so comparing
   # dirname(normalizePath(f)) == normalizePath(input_jsonl) is unreliable.
   # Counting components is immune to this because 8.3 and long names occupy
-  # the same depth in the hierarchy. ----
+  # the same depth in the hierarchy.
+  #
+  # Hive partition key naming by depth: depth 1 -> "query", depth N -> "query_lN"
+  hive_key <- function(depth) if (depth == 1L) "query" else paste0("query_l", depth)
+
   input_depth <- length(strsplit(gsub("\\\\", "/", input_jsonl), "/")[[1]])
   output_files <- vapply(jsons, function(f) {
-    f_parts <- strsplit(gsub("\\\\", "/", f), "/")[[1]]
-    fname   <- sub("\\.json$", ".parquet", basename(f))
-    rel_dir <- if (length(f_parts) > input_depth + 1L) {
-      # File is in a subdirectory relative to input_jsonl
-      paste(f_parts[seq(input_depth + 1L, length(f_parts) - 1L)], collapse = "/")
+    f_parts  <- strsplit(gsub("\\\\", "/", f), "/")[[1]]
+    fname    <- sub("\\.json$", ".parquet", basename(f))
+    rel_parts <- if (length(f_parts) > input_depth + 1L) {
+      f_parts[seq(input_depth + 1L, length(f_parts) - 1L)]
     } else {
-      ""
+      character(0)
     }
-    if (nchar(rel_dir) > 0) {
-      file.path(output, paste0("query=", rel_dir), fname)
+    if (length(rel_parts) > 0L) {
+      hive_dirs <- mapply(
+        function(depth, val) paste0(hive_key(depth), "=", val),
+        seq_along(rel_parts), rel_parts
+      )
+      do.call(file.path, c(list(output), as.list(hive_dirs), list(fname)))
     } else {
       file.path(output, fname)
     }

--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ openalexPro::pro_request(
 
 Will retrieve the records and save them into the folder specified in output. One important difference is now between the query being a single URL or a list: if it is a list, the `future` and `future.apply` packages are used to process the URLs in the list in parallel.
 
+`pro_request()` also accepts **nested lists**, which creates a mirrored nested directory structure. The subsequent `pro_request_jsonl_parquet()` step converts the directory depth into hive-style partition keys (`query=<name>`, `query_l2=<name>`, …), so the final parquet dataset can be filtered by group directly:
+
+```r
+queries <- list(
+  year_2022 = pro_query(entity = "works", publication_year = 2022),
+  year_2023 = pro_query(entity = "works", publication_year = 2023)
+)
+pro_fetch(query_url = queries, project_folder = "by_year")
+# Parquet partitions: by_year/parquet/query=year_2022/ and query=year_2023/
+arrow::open_dataset("by_year/parquet") |> dplyr::filter(query == "year_2022")
+```
+
 ### 3. Processing `json` files (`openalexPro::pro_request_jsonl()`)
 
 This step prepares the json files for the final ingestion into a `parquet` database:

--- a/tests/testthat/_snaps/009-pro_pipeline_nested.md
+++ b/tests/testthat/_snaps/009-pro_pipeline_nested.md
@@ -1,0 +1,66 @@
+# pro_request with nested list creates nested output dirs
+
+    Code
+      json_files
+    Output
+      [1] "grp_a/chunk_1/results_page_1.json" "grp_a/chunk_1/results_page_2.json"
+      [3] "grp_a/chunk_2/results_page_1.json" "grp_a/chunk_2/results_page_2.json"
+      [5] "grp_b/chunk_3/results_page_1.json" "grp_b/chunk_3/results_page_2.json"
+      [7] "grp_b/chunk_4/results_page_1.json" "grp_b/chunk_4/results_page_2.json"
+
+# pro_request_jsonl with nested subdirs
+
+    Code
+      jsonl_files
+    Output
+      [1] "grp_a/chunk_1/results_page_1.json" "grp_a/chunk_2/results_page_1.json"
+      [3] "grp_b/chunk_3/results_page_1.json" "grp_b/chunk_4/results_page_1.json"
+
+# pro_request_jsonl_parquet with nested subdirs produces hive partitions
+
+    Code
+      parquet_files
+    Output
+      [1] "query=grp_a/query_l2=chunk_1/results_page_1.parquet"
+      [2] "query=grp_a/query_l2=chunk_2/results_page_1.parquet"
+      [3] "query=grp_b/query_l2=chunk_3/results_page_1.parquet"
+      [4] "query=grp_b/query_l2=chunk_4/results_page_1.parquet"
+    Code
+      ds
+    Output
+      FileSystemDataset with 4 Parquet files
+      54 columns
+      id: string
+      doi: string
+      title: string
+      display_name: string
+      publication_year: int64
+      publication_date: date32[day]
+      ids: struct<openalex: string, doi: string, mag: string, pmid: string, pmcid: string>
+      language: string
+      primary_location: struct<is_oa: bool, landing_page_url: string, pdf_url: string, source: struct<id: string, display_name: string, issn_l: string, issn: list<element: string>, is_oa: bool, is_in_doaj: bool, is_indexed_in_scopus: bool, is_core: bool, host_organization: string, host_organization_name: string, host_organization_lineage: list<element: string>, host_organization_lineage_names: list<element: string>, type: string>, license: string, license_id: string, version: string, is_accepted: bool, is_published: bool>
+      type: string
+      type_crossref: string
+      indexed_in: list<element: string>
+      open_access: struct<is_oa: bool, oa_status: string, oa_url: string, any_repository_has_fulltext: bool>
+      authorships: list<element: struct<author_position: string, author: struct<id: string, display_name: string, orcid: string>, institutions: list<element: struct<id: string, display_name: string, ror: string, country_code: string, type: string, lineage: list<element: string>>>, countries: list<element: string>, is_corresponding: bool, raw_author_name: string, raw_affiliation_strings: list<element: string>, affiliations: list<element: struct<raw_affiliation_string: string, institution_ids: list<element: string>>>>>
+      institution_assertions: list<element: string>
+      countries_distinct_count: int64
+      institutions_distinct_count: int64
+      corresponding_author_ids: list<element: string>
+      corresponding_institution_ids: list<element: string>
+      apc_list: struct<value: int64, currency: string, value_usd: int64>
+      ...
+      34 more columns
+      Use `schema()` to see entire schema
+    Code
+      dplyr::collect(dplyr::arrange(dplyr::distinct(dplyr::select(ds, page)), page))
+    Output
+      # A tibble: 4 x 1
+        page   
+        <chr>  
+      1 chunk_1
+      2 chunk_2
+      3 chunk_3
+      4 chunk_4
+

--- a/tests/testthat/test-009-pro_pipeline_nested.R
+++ b/tests/testthat/test-009-pro_pipeline_nested.R
@@ -1,0 +1,206 @@
+library(testthat)
+library(arrow)
+library(dplyr)
+
+# ---------------------------------------------------------------------------
+# Unit tests: collect_leaf_queries helper
+# ---------------------------------------------------------------------------
+
+test_that("collect_leaf_queries: single URL", {
+  result <- collect_leaf_queries("https://example.com/works")
+  expect_length(result, 1L)
+  expect_equal(result[[1]]$url, "https://example.com/works")
+  expect_equal(result[[1]]$path, character(0))
+})
+
+test_that("collect_leaf_queries: flat named list", {
+  q <- list(a = "https://a.com", b = "https://b.com")
+  result <- collect_leaf_queries(q)
+  expect_length(result, 2L)
+  expect_equal(result[[1]]$path, "a")
+  expect_equal(result[[2]]$path, "b")
+  expect_equal(result[[1]]$url, "https://a.com")
+})
+
+test_that("collect_leaf_queries: flat unnamed list", {
+  q <- list("https://a.com", "https://b.com")
+  result <- collect_leaf_queries(q)
+  expect_length(result, 2L)
+  expect_equal(result[[1]]$path, "query_1")
+  expect_equal(result[[2]]$path, "query_2")
+})
+
+test_that("collect_leaf_queries: two-level nesting", {
+  q <- list(
+    grp_a = list(x = "https://a.com", y = "https://b.com"),
+    grp_b = "https://c.com"
+  )
+  result <- collect_leaf_queries(q)
+  expect_length(result, 3L)
+  expect_equal(result[[1]]$path, c("grp_a", "x"))
+  expect_equal(result[[2]]$path, c("grp_a", "y"))
+  expect_equal(result[[3]]$path, c("grp_b"))
+})
+
+test_that("collect_leaf_queries: three-level nesting", {
+  q <- list(l1 = list(l2 = list(l3 = "https://deep.com")))
+  result <- collect_leaf_queries(q)
+  expect_length(result, 1L)
+  expect_equal(result[[1]]$path, c("l1", "l2", "l3"))
+  expect_equal(result[[1]]$url, "https://deep.com")
+})
+
+# ---------------------------------------------------------------------------
+# Integration test: pro_request_jsonl_parquet with nested JSONL directories
+# ---------------------------------------------------------------------------
+
+make_minimal_jsonl <- function(path, n = 2L, page = 1L) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  lines <- vapply(
+    seq_len(n),
+    function(i) sprintf('{"id":"W%d%d","title":"Paper %d","page":%d}', page, i, i, page),
+    character(1)
+  )
+  writeLines(lines, path)
+}
+
+test_that("pro_request_jsonl_parquet: two-level hive partitioning", {
+  base_jsonl <- file.path(tempdir(), "nested_jsonl_test")
+  base_parquet <- file.path(tempdir(), "nested_parquet_test")
+  on.exit({
+    unlink(base_jsonl, recursive = TRUE, force = TRUE)
+    unlink(base_parquet, recursive = TRUE, force = TRUE)
+  })
+
+  # Build two-level nested JSONL structure
+  # grp_a/sub_x/results_page_1.json
+  # grp_a/sub_y/results_page_1.json
+  # grp_b/results_page_1.json
+  make_minimal_jsonl(file.path(base_jsonl, "grp_a", "sub_x", "results_page_1.json"), page = 1L)
+  make_minimal_jsonl(file.path(base_jsonl, "grp_a", "sub_y", "results_page_1.json"), page = 1L)
+  make_minimal_jsonl(file.path(base_jsonl, "grp_b",          "results_page_1.json"), page = 1L)
+
+  out <- pro_request_jsonl_parquet(
+    input_jsonl = base_jsonl,
+    output = base_parquet,
+    verbose = FALSE
+  )
+
+  parquet_files <- sort(list.files(out, "*.parquet", recursive = TRUE))
+
+  # Expect hive-partitioned paths
+  expect_true(any(grepl("^query=grp_a/query_l2=sub_x/", parquet_files)))
+  expect_true(any(grepl("^query=grp_a/query_l2=sub_y/", parquet_files)))
+  expect_true(any(grepl("^query=grp_b/",                parquet_files)))
+
+  # Dataset readable as a whole
+  ds <- arrow::open_dataset(out)
+  expect_true("id" %in% names(ds))
+  expect_gt(nrow(dplyr::collect(ds)), 0L)
+})
+
+test_that("pro_request_jsonl_parquet: single-level hive partitioning unchanged", {
+  base_jsonl <- file.path(tempdir(), "flat_jsonl_test")
+  base_parquet <- file.path(tempdir(), "flat_parquet_test")
+  on.exit({
+    unlink(base_jsonl, recursive = TRUE, force = TRUE)
+    unlink(base_parquet, recursive = TRUE, force = TRUE)
+  })
+
+  make_minimal_jsonl(file.path(base_jsonl, "chunk_1", "results_page_1.json"), page = 1L)
+  make_minimal_jsonl(file.path(base_jsonl, "chunk_2", "results_page_1.json"), page = 1L)
+
+  out <- pro_request_jsonl_parquet(
+    input_jsonl = base_jsonl,
+    output = base_parquet,
+    verbose = FALSE
+  )
+
+  parquet_files <- sort(list.files(out, "*.parquet", recursive = TRUE))
+  expect_true(any(grepl("^query=chunk_1/", parquet_files)))
+  expect_true(any(grepl("^query=chunk_2/", parquet_files)))
+  # No second-level partition key
+  expect_false(any(grepl("query_l2=", parquet_files)))
+})
+
+# ---------------------------------------------------------------------------
+# Integration test: nested pro_request with VCR cassettes
+# ---------------------------------------------------------------------------
+
+output_json_nested    <- file.path(tempdir(), "nested_json")
+output_jsonl_nested   <- file.path(tempdir(), "nested_jsonl")
+output_parquet_nested <- file.path(tempdir(), "nested_parquet")
+
+unlink(output_json_nested,    recursive = TRUE, force = TRUE)
+unlink(output_jsonl_nested,   recursive = TRUE, force = TRUE)
+unlink(output_parquet_nested, recursive = TRUE, force = TRUE)
+
+dois <- readRDS(testthat::test_path("..", "fixtures", "dois.rds"))
+
+build_nested_req <- function(dois) {
+  vcr::local_cassette("opt_filter_names")
+  flat <- pro_query(entity = "works", doi = dois)
+  # wrap two flat chunks into a two-level nested list
+  list(
+    grp_a = flat[seq_len(floor(length(flat) / 2))],
+    grp_b = flat[seq(floor(length(flat) / 2) + 1L, length(flat))]
+  )
+}
+
+test_that("pro_request with nested list creates nested output dirs", {
+  req <- build_nested_req(dois)
+  vcr::local_cassette("pro_request_parallel")
+
+  out <- pro_request(
+    query_url = req,
+    output    = output_json_nested,
+    verbose   = FALSE,
+    progress  = TRUE
+  )
+
+  json_files <- sort(list.files(output_json_nested, "*.json", recursive = TRUE))
+  # All files should be under grp_a/* or grp_b/*
+  expect_true(all(grepl("^grp_[ab]/", json_files)))
+  expect_snapshot(json_files)
+})
+
+test_that("pro_request_jsonl with nested subdirs", {
+  out <- pro_request_jsonl(
+    input  = output_json_nested,
+    output = output_jsonl_nested,
+    verbose = FALSE,
+    progress = TRUE
+  )
+
+  jsonl_files <- sort(list.files(output_jsonl_nested, "*.json", recursive = TRUE))
+  expect_true(all(grepl("^grp_[ab]/", jsonl_files)))
+  expect_snapshot(jsonl_files)
+})
+
+test_that("pro_request_jsonl_parquet with nested subdirs produces hive partitions", {
+  out <- pro_request_jsonl_parquet(
+    input_jsonl = output_jsonl_nested,
+    output      = output_parquet_nested,
+    verbose     = FALSE
+  )
+
+  parquet_files <- sort(list.files(out, "*.parquet", recursive = TRUE))
+  expect_true(any(grepl("^query=grp_a/query_l2=", parquet_files)))
+  expect_true(any(grepl("^query=grp_b/query_l2=", parquet_files)))
+
+  ds <- arrow::open_dataset(out)
+  expect_true("id" %in% names(ds))
+  expect_snapshot({
+    parquet_files
+    ds
+    ds |>
+      dplyr::select(page) |>
+      dplyr::distinct() |>
+      dplyr::arrange(page) |>
+      dplyr::collect()
+  })
+})
+
+unlink(output_json_nested,    recursive = TRUE, force = TRUE)
+unlink(output_jsonl_nested,   recursive = TRUE, force = TRUE)
+unlink(output_parquet_nested, recursive = TRUE, force = TRUE)

--- a/vignettes/pro_request.qmd
+++ b/vignettes/pro_request.qmd
@@ -166,6 +166,52 @@ pro_request(
 # Creates: data/json/chunk_1/, data/json/chunk_2/, data/json/chunk_3/
 ```
 
+## Nested List Queries
+
+`pro_request()` also accepts **nested lists** of URLs. Each nesting level is preserved as a subdirectory, and `pro_request_jsonl_parquet()` converts the directory depth to hive-style partition keys:
+
+| Directory depth | Partition key |
+|----------------|--------------|
+| 1 | `query=<name>` |
+| 2 | `query_l2=<name>` |
+| 3 | `query_l3=<name>` |
+
+```{r}
+# Build a nested query list manually
+queries <- list(
+  year_2022 = pro_query(entity = "works", publication_year = 2022),
+  year_2023 = pro_query(entity = "works", publication_year = 2023),
+  institutions = list(
+    usa = pro_query(entity = "institutions", country_code = "US"),
+    uk  = pro_query(entity = "institutions", country_code = "GB")
+  )
+)
+
+# Download: creates nested subdirectory structure
+pro_request(
+  query_url = queries,
+  output    = "data/json"
+)
+# Creates:
+#   data/json/year_2022/
+#   data/json/year_2023/
+#   data/json/institutions/usa/
+#   data/json/institutions/uk/
+
+# After jsonl + parquet conversion the dataset is hive-partitioned:
+#   data/parquet/query=year_2022/
+#   data/parquet/query=year_2023/
+#   data/parquet/query=institutions/query_l2=usa/
+#   data/parquet/query=institutions/query_l2=uk/
+
+# Filter by partition
+ds <- arrow::open_dataset("data/parquet")
+ds |> dplyr::filter(query == "year_2022")
+ds |> dplyr::filter(query == "institutions", query_l2 == "usa")
+```
+
+`pro_fetch()` inherits nested list support automatically — you can pass a nested list directly as `query_url`.
+
 ## Parallel Downloads
 
 For chunked queries, enable parallel processing:
@@ -739,20 +785,42 @@ flowchart LR
 
 ## Output Structure
 
-The Parquet dataset is partitioned by the `page` field:
+For a flat (single-URL) input:
 
 ```
 data/parquet/
-├── page=chunk_1_1/
-│   └── data_0.parquet
-├── page=chunk_1_2/
-│   └── data_0.parquet
-├── page=chunk_2_1/
-│   └── data_0.parquet
+├── results_page_1.parquet
+├── results_page_2.parquet
 └── ...
 ```
 
-This partitioning enables efficient filtering when querying subsets of the data.
+For a flat list of URLs (e.g. `chunk_1`, `chunk_2` from auto-chunking):
+
+```
+data/parquet/
+├── query=chunk_1/
+│   ├── results_page_1.parquet
+│   └── results_page_2.parquet
+└── query=chunk_2/
+    └── results_page_1.parquet
+```
+
+For a two-level nested list:
+
+```
+data/parquet/
+├── query=year_2022/
+│   └── results_page_1.parquet
+├── query=year_2023/
+│   └── results_page_1.parquet
+└── query=institutions/
+    ├── query_l2=usa/
+    │   └── results_page_1.parquet
+    └── query_l2=uk/
+        └── results_page_1.parquet
+```
+
+The hive partition columns (`query`, `query_l2`, …) become regular columns when you open the dataset with `arrow::open_dataset()`, enabling efficient predicate pushdown.
 
 ---
 


### PR DESCRIPTION
## Summary

- `pro_request()`, `pro_request_jsonl()`, and `pro_request_jsonl_parquet()` now accept arbitrarily nested lists of query URLs
- Each nesting level is preserved as a subdirectory; the parquet stage converts depth to hive partition keys: `query=`, `query_l2=`, `query_l3=`, …
- New internal helper `collect_leaf_queries()` performs recursive list flattening
- `pro_fetch()` inherits nested list support automatically
- Version bumped to 0.8.0

## Behavior changes

No breaking changes. All existing flat-list and scalar inputs work exactly as before.

**New**: nested list input:
```r
pro_fetch(
  list(
    year_2022 = pro_query("works", publication_year = 2022),
    institutions = list(
      usa = pro_query("institutions", country_code = "US"),
      uk  = pro_query("institutions", country_code = "GB")
    )
  ),
  project_folder = "out"
)
# out/parquet/query=year_2022/
# out/parquet/query=institutions/query_l2=usa/
# out/parquet/query=institutions/query_l2=uk/
```

## Files changed

| File | Change |
|------|--------|
| `R/pro_request.R` | Recursive `collect_leaf_queries()` helper; list branch uses it |
| `R/pro_request_jsonl.R` | Full relative path preserved for nested subdirs |
| `R/pro_request_jsonl_parquet.R` | Multi-level hive partition key naming |
| `tests/testthat/test-009-pro_pipeline_nested.R` | 33 new tests (unit + integration) |
| `DESCRIPTION` | Version 0.7.0 → 0.8.0 |
| `NEWS.md` | Feature entry under `(development)` |
| `CLAUDE.md` | Updated architecture + conventions |
| `README.md` | Nested list example in Advanced Workflow |
| `vignettes/pro_request.qmd` | New "Nested List Queries" section; updated output structure trees |

## Test plan

- [x] `devtools::test()` → FAIL 0 | WARN 0 | PASS 260 (6 expected skips)
- [x] `devtools::check()` → 0 errors | 0 warnings | 1 pre-existing note
- [x] 33 dedicated tests in `test-009`: unit tests for `collect_leaf_queries()`, synthetic JSONL partitioning at 1 and 2 levels, full VCR-replayed nested API pipeline

🤖 Generated with [Claude Code](https://claude.ai/claude-code)