### PR TITLE
Fix overwrite parameter in pro_request() list mode and pro_fetch() (v0.8.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openalexPro
 Title: Providing a more advanced access to OpenAlex for the power user
-Version: 0.8.0
+Version: 0.8.1
 Author: Rainer M Krug
 Maintainer: Rainer M Krug <Rainer@krugs.de>
 Description: More about what it does (maybe more than one line).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,6 +6,34 @@ development history for the `openalexPro` package. It is aimed at future contrib
 
 ---
 
+## 2026-04-20 — Fix `overwrite` parameter in `pro_request()` list method and `pro_fetch()` (0.8.1)
+
+**Bug:** `pro_request()` accepted an `overwrite` parameter but silently ignored
+it when `query_url` was a list — the top-level output directory was never
+checked or deleted, and each sub-query's `fetch_query_pages()` call received
+`overwrite = FALSE` hardcoded, so re-running with an existing output caused
+cryptic per-subdirectory errors rather than a clean atomic overwrite.
+
+**Fix (`R/pro_request.R`):** Added an upfront check in the list method before
+flattening queries: error if `output` exists and `overwrite = FALSE`; delete
+it with `unlink(recursive = TRUE)` if `overwrite = TRUE`. Sub-function calls
+keep `overwrite = FALSE` (the directory no longer exists by the time they run).
+
+**Bug:** `pro_fetch()` delegated `overwrite` to each of the three sub-functions
+(`pro_request`, `pro_request_jsonl`, `pro_request_jsonl_parquet`) individually,
+so directories were deleted one at a time as the pipeline progressed. If
+`overwrite = FALSE` and only `jsonl/` existed (not `json/`), the first step
+would succeed silently and only fail on the second.
+
+**Fix (`R/pro_fetch.R`):** Upfront check across all three subdirectories before
+starting the pipeline: collect which of `json/`, `jsonl/`, `parquet/` exist,
+error with a combined message if `overwrite = FALSE`, delete all existing ones
+if `overwrite = TRUE`. Sub-functions receive `overwrite = FALSE`.
+
+**Key files:** `R/pro_request.R`, `R/pro_fetch.R`
+
+---
+
 ## 2026-04-16 — Wrap `openalex-snapshot` binary; add `*_R()` fallbacks (0.7.0)
 
 **Motivation:** The companion Rust CLI `openalex-snapshot` is now more capable

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # openalexPro (development)
 
+# openalexPro 0.8.1
+
+## Bug Fixes
+
+* `pro_request()` list method now respects the `overwrite` parameter. Previously,
+  when `query_url` was a list, the top-level `output` directory was neither
+  checked nor deleted regardless of `overwrite`. It now errors if the directory
+  exists and `overwrite = FALSE`, and deletes it upfront if `overwrite = TRUE`.
+
+* `pro_fetch()` now deletes all three subdirectories (`json`, `jsonl`, `parquet`)
+  upfront before the pipeline starts when `overwrite = TRUE`, rather than
+  delegating deletion to each sub-function individually. If any of the
+  subdirectories exist and `overwrite = FALSE`, the function now errors
+  immediately with a clear message listing which directories already exist.
+
+# openalexPro 0.8.0
+
 ## New Features
 
 * `pro_request()`, `pro_request_jsonl()`, and `pro_request_jsonl_parquet()`

--- a/R/pro_fetch.R
+++ b/R/pro_fetch.R
@@ -29,6 +29,11 @@
 #'   \code{jsonl}) and final (\code{parquet}) results are stored.
 #'   If it does not exist, it is created. If \code{NULL}, a temporary
 #'   directory is created.
+#' @param overwrite Logical. If \code{TRUE}, all three subdirectories
+#'   (\code{json}, \code{jsonl}, \code{parquet}) are deleted from
+#'   \code{project_folder} before the pipeline starts. If \code{FALSE} (the
+#'   default) and any of those subdirectories already exist, the function stops
+#'   with an error.
 #'
 #' @return Invisibly, the normalized path of the \code{parquet} subfolder
 #'   inside \code{project_folder}, i.e. the value returned by

--- a/R/pro_fetch.R
+++ b/R/pro_fetch.R
@@ -73,11 +73,26 @@ pro_fetch <- function(
     )
   }
 
+  subdirs <- c("json", "jsonl", "parquet")
+  existing <- subdirs[dir.exists(file.path(project_folder, subdirs))]
+  if (length(existing) > 0) {
+    if (!overwrite) {
+      stop(
+        "The following subdirectories already exist in '", project_folder, "': ",
+        paste(existing, collapse = ", "), ".\n",
+        "Either specify `overwrite = TRUE` or delete them."
+      )
+    }
+    for (d in existing) {
+      unlink(file.path(project_folder, d), recursive = TRUE)
+    }
+  }
+
   pro_request(
     query_url = query_url,
     pages = pages,
     output = file.path(project_folder, "json"),
-    overwrite = overwrite,
+    overwrite = FALSE,
     api_key = api_key,
     workers = workers,
     verbose = verbose,
@@ -87,14 +102,14 @@ pro_fetch <- function(
   ) |>
     pro_request_jsonl(
       output = file.path(project_folder, "jsonl"),
-      overwrite = overwrite,
+      overwrite = FALSE,
       progress = progress,
       delete_input = FALSE,
       workers = workers
     ) |>
     pro_request_jsonl_parquet(
       output = file.path(project_folder, "parquet"),
-      overwrite = overwrite,
+      overwrite = FALSE,
       verbose = verbose,
       delete_input = FALSE
     )

--- a/R/pro_request.R
+++ b/R/pro_request.R
@@ -79,6 +79,17 @@ pro_request <- function(
       future::plan(future::sequential)
     }
 
+    # Delete output directory upfront if overwrite requested
+    if (!is.null(output) && dir.exists(output)) {
+      if (!overwrite) {
+        stop(
+          "Directory ", output, " exists.\n",
+          "Either specify `overwrite = TRUE` or delete it."
+        )
+      }
+      unlink(output, recursive = TRUE)
+    }
+
     # Flatten nested list to leaf (URL, path) pairs
     leaf_queries <- collect_leaf_queries(query_url)
     leaf_urls    <- vapply(leaf_queries, `[[`, character(1), "url")

--- a/R/pro_request.R
+++ b/R/pro_request.R
@@ -18,8 +18,10 @@
 #'   all pages will be downloaded. Default: 100000.
 #' @param output directory where the JSON files are saved. Default is a
 #'   temporary directory. Needs to be specified.
-#' @param overwrite Logical. If `TRUE`, `output` will be deleted if it already
-#'   exists.
+#' @param overwrite Logical. If `TRUE`, `output` will be deleted before
+#'   downloading. For a list `query_url`, the entire top-level `output`
+#'   directory is removed upfront. If `FALSE` (the default) and `output`
+#'   already exists, the function stops with an error.
 #' @param api_key Character string API key or `NULL`. Defaults to
 #'   `Sys.getenv("openalexPro.apikey")`. If `NULL` or `""`, requests are sent
 #'   without an API key (subject to OpenAlex's unauthenticated limits).

--- a/man/pro_fetch.Rd
+++ b/man/pro_fetch.Rd
@@ -30,8 +30,11 @@ all pages will be downloaded. Default: 100000.}
 If it does not exist, it is created. If \code{NULL}, a temporary
 directory is created.}
 
-\item{overwrite}{Logical. If \code{TRUE}, \code{output} will be deleted if it already
-exists.}
+\item{overwrite}{Logical. If \code{TRUE}, all three subdirectories
+(\code{json}, \code{jsonl}, \code{parquet}) are deleted from
+\code{project_folder} before the pipeline starts. If \code{FALSE} (the
+default) and any of those subdirectories already exist, the function stops
+with an error.}
 
 \item{api_key}{Character string API key or \code{NULL}. Defaults to
 \code{Sys.getenv("openalexPro.apikey")}. If \code{NULL} or \code{""}, requests are sent

--- a/man/pro_request.Rd
+++ b/man/pro_request.Rd
@@ -28,8 +28,10 @@ all pages will be downloaded. Default: 100000.}
 \item{output}{directory where the JSON files are saved. Default is a
 temporary directory. Needs to be specified.}
 
-\item{overwrite}{Logical. If \code{TRUE}, \code{output} will be deleted if it already
-exists.}
+\item{overwrite}{Logical. If \code{TRUE}, \code{output} will be deleted before
+downloading. For a list \code{query_url}, the entire top-level \code{output}
+directory is removed upfront. If \code{FALSE} (the default) and \code{output}
+already exists, the function stops with an error.}
 
 \item{api_key}{Character string API key or \code{NULL}. Defaults to
 \code{Sys.getenv("openalexPro.apikey")}. If \code{NULL} or \code{""}, requests are sent


### PR DESCRIPTION
## Summary

- **`pro_request()` list method**: `overwrite` was accepted but never acted on when `query_url` is a list — the output directory was neither checked nor deleted. Now errors if the directory exists with `overwrite = FALSE`; deletes it upfront if `overwrite = TRUE`.
- **`pro_fetch()`**: `overwrite` was delegated to each sub-function individually, deleting directories one at a time mid-pipeline. Now checks all three subdirectories (`json/`, `jsonl/`, `parquet/`) upfront: errors with a combined message listing which exist if `overwrite = FALSE`; deletes all existing ones atomically if `overwrite = TRUE`.
- Version bumped 0.8.0 → 0.8.1; NEWS.md and DEVELOPMENT.md updated; roxygen docs regenerated.

## Test plan

- [x] 260 tests pass, 0 fail, 6 expected skips
- [x] `devtools::document()` regenerated `man/pro_fetch.Rd` and `man/pro_request.Rd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)