### PR TITLE
Route opt_filter_names() and opt_select_fields() through api_call()

### DIFF
--- a/R/opt_filter_names.R
+++ b/R/opt_filter_names.R
@@ -3,7 +3,7 @@
 #' @param update logical. If `TRUE` update the existing value. Default is `FALSE`.
 #' @return A character vector of available filter names
 #'
-#' @importFrom httr2 request req_url_query req_error req_perform resp_body_json
+#' @importFrom httr2 request req_url_query resp_body_json
 #' @export
 opt_filter_names <- function(update = FALSE) {
   if (update) {
@@ -16,8 +16,7 @@ opt_filter_names <- function(update = FALSE) {
     url <- "https://api.openalex.org/works?filter=DOESNTEXIST%3A1"
     resp <- httr2::request("https://api.openalex.org/works") |>
       httr2::req_url_query(filter = "DOESNTEXIST:1") |>
-      httr2::req_error(is_error = ~FALSE) |> # don't throw on HTTP errors
-      httr2::req_perform() |>
+      api_call(get_html_response = NULL) |>
       httr2::resp_body_json()
 
     filter <- resp$message |>

--- a/R/opt_select_fields.R
+++ b/R/opt_select_fields.R
@@ -3,7 +3,7 @@
 #' @param update logical. If `TRUE` update the existing value. Default is `FALSE`.
 #' @return A character vector of available select fields
 #'
-#' @importFrom httr2 request req_url_query req_error req_perform resp_body_json
+#' @importFrom httr2 request req_url_query resp_body_json
 #' @export
 opt_select_fields <- function(update = FALSE) {
   if (update) {
@@ -15,8 +15,7 @@ opt_select_fields <- function(update = FALSE) {
   if (is.null(getOption("openalexPro")$select_fields)) {
     resp <- httr2::request("https://api.openalex.org/works/W1775749144") |>
       httr2::req_url_query(select = "DOESNTEXIST") |>
-      httr2::req_error(is_error = ~FALSE) |> # don't throw on HTTP errors
-      httr2::req_perform() |>
+      api_call(get_html_response = NULL) |>
       httr2::resp_body_json()
 
     select <- resp$message |>


### PR DESCRIPTION
## Summary

- Both `opt_filter_names()` and `opt_select_fields()` called `httr2::req_perform()` directly, bypassing `api_call()` and its retry/error-handling logic.
- Replace `req_error(is_error = ~FALSE) |> req_perform()` with `api_call(get_html_response = NULL)` in both files. `get_html_response = NULL` preserves the pass-through behaviour for HTTP 400 responses (which both functions rely on to extract valid field names from the error message).
- Remove `req_error` and `req_perform` from `@importFrom httr2` declarations.

## Test plan

- [x] `devtools::test(filter = "003")` — all 39 tests pass; expected `⚠ HTTP 400` log lines appear (consistent with other `api_call(get_html_response = NULL)` callers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)