### PR TITLE
Add openalexPro.ratelimit_check debug option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,11 @@ Each test file (`test-011`, `test-012`, `test-013`) has two sections:
 - Merge into `dev` (never commit directly to `main`)
 - `main` receives only release commits
 
+## Debug Options
+
+- `options(openalexPro.ratelimit_check = TRUE)` — print rate-limit status before every API call (via `api_call()`)
+- `options(openalexPro.oas_bin = "/path/to/openalex-snapshot")` — override binary path for snapshot functions
+
 ## Key Conventions
 
 - `project_dir` is the standard output directory parameter (consistent across `pro_fetch()`, `pro_request()`, `lookup_by_id()`)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # openalexPro (development)
 
+## New Features
+
+* New debug option `openalexPro.ratelimit_check`: when set to `TRUE` via
+  `options(openalexPro.ratelimit_check = TRUE)`, every API call prints the
+  current rate-limit status (budget, usage, remaining, reset time) as a message
+  before the request is sent. Internally handled in `api_call()` using
+  `pro_rate_limit_status(verbose = TRUE)`. A recursion guard temporarily
+  disables the option during the nested rate-limit request.
+
 # openalexPro 0.8.1
 
 ## Bug Fixes

--- a/R/api_call.R
+++ b/R/api_call.R
@@ -22,6 +22,13 @@
 #'
 #' @return An \code{httr2} response object (on success, or per get_html_response rules), or aborts.
 #'
+#' @section Debug option:
+#' When \code{options(openalexPro.ratelimit_check = TRUE)}, \code{api_call()}
+#' calls \code{pro_rate_limit_status(verbose = TRUE)} before every request,
+#' printing the current API budget and usage as a message. The option is
+#' temporarily set to \code{FALSE} during the nested rate-limit call to prevent
+#' infinite recursion.
+#'
 #' @importFrom httr2 req_retry req_error req_perform resp_status resp_header
 #' @importFrom rlang caller_env abort
 #' @noRd
@@ -32,6 +39,15 @@ api_call <- function(
   error_log = NULL,
   get_html_response
 ) {
+  # Rate-limit debug check: print status before each call when option is set.
+  # Temporarily disabled during the nested pro_rate_limit_status() call to
+  # prevent infinite recursion (pro_rate_limit_status → api_call → ...).
+  if (isTRUE(getOption("openalexPro.ratelimit_check"))) {
+    options(openalexPro.ratelimit_check = FALSE)
+    on.exit(options(openalexPro.ratelimit_check = TRUE), add = TRUE)
+    pro_rate_limit_status(verbose = TRUE)
+  }
+
   # simple logger
   log_fun <- function(msg, log_file) {
     timestamp <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")


### PR DESCRIPTION
## Summary

- New debug option: `options(openalexPro.ratelimit_check = TRUE)` causes `api_call()` to call `pro_rate_limit_status(verbose = TRUE)` before every API request, printing current budget/usage/remaining/reset time as a message.
- Recursion guard: the option is temporarily set to `FALSE` during the nested rate-limit call (since `pro_rate_limit_status()` itself calls `api_call()`), then restored via `on.exit`.
- Docs updated: NEWS.md (development section), CLAUDE.md (new Debug Options section), inline roxygen in `api_call.R`.

## Usage

```r
options(openalexPro.ratelimit_check = TRUE)
pro_request(query_url = url, output = "data/json")
# ℹ Daily budget:    $1 ...  (printed before every page request)
```

## Test plan

- [x] Tests 003, 004, 005, 015 pass; rate-limit message visible in test-015 output

🤖 Generated with [Claude Code](https://claude.com/claude-code)