### PR TITLE
Add doi parameter to pro_query() with automatic chunking

### DIFF
--- a/R/pro_query.R
+++ b/R/pro_query.R
@@ -181,6 +181,9 @@
 #' @param id Optional ID or vector of IDs (e.g., \code{"W1775749144"}). If a single ID
 #'   is provided, fetches one entity directly. If multiple IDs are provided, they are
 #'   automatically moved into the \code{ids.openalex} filter.
+#' @param doi Optional DOI or vector of DOIs (e.g., \code{"10.1038/s41586-021-03819-2"}).
+#'   Values are moved into the \code{doi} filter and automatically chunked into
+#'   separate requests when the number of DOIs exceeds \code{chunk_limit}.
 #' @param search Optional full-text search string. Applies stemming and
 #'   stop-word removal. Supports boolean operators (\code{AND}, \code{OR},
 #'   \code{NOT} in uppercase), quoted phrases (\code{"exact phrase"}),
@@ -256,6 +259,7 @@ pro_query <- function(
     "funders"
   ),
   id = NULL,
+  doi = NULL,
   search = NULL,
   search.exact = NULL,
   search.semantic = NULL,
@@ -284,6 +288,11 @@ pro_query <- function(
   if (length(id) > 1) {
     filter <- c(filter, list(`ids.openalex` = unique(id)))
     id <- NULL
+  }
+
+  # move DOIs into filter (always via filter; chunked automatically)
+  if (!is.null(doi) && length(doi) > 0) {
+    filter <- c(filter, list(doi = unique(doi)))
   }
 
   # validate filters and select fields


### PR DESCRIPTION
## Summary

`doi` was already listed in `chunk_targets` so the chunking infrastructure existed, but there was no dedicated `doi` parameter — users had to pass DOIs as `doi = c(...)` via `...` (undiscoverable and inconsistent with how `id` is handled).

The new `doi = NULL` parameter mirrors `id`: values are moved into `filter[["doi"]]` and automatically chunked into `chunk_limit`-sized requests (default 50).

```r
# 120 DOIs → 3 chunks of 50 automatically
urls <- pro_query(entity = "works", doi = my_dois)
length(urls)  # 3
```

## Test plan

- [x] Smoke-tested: 120 DOIs with `chunk_limit = 50` → 3 named chunks
- [x] Full suite: 260 passed, 0 failed, 6 expected skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)