### PR TITLE
Silence expected HTTP 400 message in api_call() when get_html_response = NULL

### DIFF
--- a/R/api_call.R
+++ b/R/api_call.R
@@ -122,15 +122,6 @@ api_call <- function(
       class = "unexpected_http_status"
     )
   } else if (is.null(get_html_response)) {
-    # returned for all non-200
-    log_fun(
-      paste0(
-        "\u26A0 HTTP ",
-        status,
-        " - returning response for caller inspection"
-      ),
-      error_log
-    )
     return(resp)
   } else if (is.numeric(get_html_response) && status == get_html_response) {
     ct <- httr2::resp_header(resp, "content-type")


### PR DESCRIPTION
## Summary

- Removes the `⚠ HTTP 400 - returning response for caller inspection` console message from `api_call()` when `get_html_response = NULL`
- Callers passing `get_html_response = NULL` have explicitly opted in to receiving non-200 responses, so the message was redundant noise
- Fixes the spurious warnings seen when calling `opt_filter_names()` and `opt_select_fields()` for the first time in a session

## Test plan

- [ ] Call `opt_filter_names()` in a fresh R session — no `⚠ HTTP 400` message should appear
- [ ] Call `opt_select_fields()` in a fresh R session — no `⚠ HTTP 400` message should appear
- [ ] Confirm `pro_query(entity = "works", doi = paste0("10.1234/example.", 1:120))` runs silently

🤖 Generated with [Claude Code](https://claude.com/claude-code)