### PR TITLE
fix: handle abstract_inverted_index duplicate keys in pro_request_parquet()

### DIFF
--- a/R/pro_request_parquet.R
+++ b/R/pro_request_parquet.R
@@ -139,9 +139,12 @@ pro_request_parquet <- function(
 
   if (!is.null(array_field)) {
     # Paginated case: {"results":[...], "meta":{...}}
-    # Describe the schema of items inside the array
+    # Describe the schema of items inside the array.
+    # ignore_errors=true is required for OpenAlex works data: abstract_inverted_index
+    # can contain duplicate struct keys (e.g. "the" and "The") which DuckDB's
+    # struct auto-detection rejects. We override the type to VARCHAR below.
     schema_sql <- sprintf(
-      "DESCRIBE SELECT r.* FROM (SELECT unnest(%s) AS r FROM read_json(%s%s))",
+      "DESCRIBE SELECT r.* FROM (SELECT unnest(%s) AS r FROM read_json(%s, ignore_errors = true%s))",
       array_field, files_sql, sample_opt
     )
     schema_df <- tryCatch(
@@ -152,6 +155,12 @@ pro_request_parquet <- function(
       }
     )
     if (!is.null(schema_df) && nrow(schema_df) > 0L) {
+      # Store abstract_inverted_index as raw VARCHAR (same as snapshot pipeline).
+      # DuckDB folds STRUCT field names to lowercase, so duplicate-cased words
+      # (e.g. "the"/"The") cause parse errors. Storing as VARCHAR avoids this;
+      # works_abstract_expr() reads the VARCHAR field via map_entries().
+      aii_row <- schema_df$column_name == "abstract_inverted_index"
+      if (any(aii_row)) schema_df$column_type[aii_row] <- "VARCHAR"
       # Build STRUCT(...) item type and wrap as LIST
       struct_fields <- paste(schema_df$column_name, schema_df$column_type, sep = " ")
       list_type <- paste0(
@@ -160,11 +169,19 @@ pro_request_parquet <- function(
     }
   } else {
     # Single-record case: bare JSON object
-    schema_sql <- sprintf("DESCRIBE SELECT * FROM read_json(%s%s)", files_sql, sample_opt)
+    # ignore_errors=true for the same duplicate-key reason as above.
+    schema_sql <- sprintf(
+      "DESCRIBE SELECT * FROM read_json(%s, ignore_errors = true%s)",
+      files_sql, sample_opt
+    )
     schema_df <- tryCatch(
       DBI::dbGetQuery(con, schema_sql),
       error = function(e) NULL
     )
+    if (!is.null(schema_df) && nrow(schema_df) > 0L) {
+      aii_row <- schema_df$column_name == "abstract_inverted_index"
+      if (any(aii_row)) schema_df$column_type[aii_row] <- "VARCHAR"
+    }
   }
 
   DBI::dbDisconnect(con, shutdown = TRUE)
@@ -384,8 +401,10 @@ pro_request_parquet_R <- function(
 
   if (!is.null(array_field)) {
     # Paginated case: {"results":[...], "meta":{...}}
+    # ignore_errors=true: OpenAlex works abstract_inverted_index can have duplicate
+    # struct keys (e.g. "the"/"The"); DuckDB struct detection rejects these.
     schema_sql <- sprintf(
-      "DESCRIBE SELECT r.* FROM (SELECT unnest(%s) AS r FROM read_json(%s%s))",
+      "DESCRIBE SELECT r.* FROM (SELECT unnest(%s) AS r FROM read_json(%s, ignore_errors = true%s))",
       array_field, files_sql, sample_opt
     )
     schema_df <- tryCatch(
@@ -396,17 +415,28 @@ pro_request_parquet_R <- function(
       }
     )
     if (!is.null(schema_df) && nrow(schema_df) > 0L) {
+      # Store abstract_inverted_index as VARCHAR to avoid duplicate-key struct errors.
+      aii_row <- schema_df$column_name == "abstract_inverted_index"
+      if (any(aii_row)) schema_df$column_type[aii_row] <- "VARCHAR"
       struct_fields <- paste(schema_df$column_name, schema_df$column_type, sep = " ")
       list_type <- paste0(
         "STRUCT(", paste(struct_fields, collapse = ", "), ")[]"
       )
     }
   } else {
-    schema_sql <- sprintf("DESCRIBE SELECT * FROM read_json(%s%s)", files_sql, sample_opt)
+    # ignore_errors=true for the same duplicate-key reason as above.
+    schema_sql <- sprintf(
+      "DESCRIBE SELECT * FROM read_json(%s, ignore_errors = true%s)",
+      files_sql, sample_opt
+    )
     schema_df <- tryCatch(
       DBI::dbGetQuery(con, schema_sql),
       error = function(e) NULL
     )
+    if (!is.null(schema_df) && nrow(schema_df) > 0L) {
+      aii_row <- schema_df$column_name == "abstract_inverted_index"
+      if (any(aii_row)) schema_df$column_type[aii_row] <- "VARCHAR"
+    }
   }
 
   DBI::dbDisconnect(con, shutdown = TRUE)


### PR DESCRIPTION
## Summary

- `pro_request_parquet()` schema inference (`DESCRIBE` step) was failing on OpenAlex works data because `abstract_inverted_index` can contain duplicate struct keys (e.g. `"the"` and `"The"`), which DuckDB's struct auto-detection rejects with *"Duplicate name 'the' in struct"*
- When inference failed, `list_type` was `NULL`, causing the Rust backend to fall back to `read_json_auto()` — which hits the same error → no parquet files written
- Fix: add `ignore_errors = true` to the `DESCRIBE` queries (schema inference only — no records are dropped) and override `abstract_inverted_index` to `VARCHAR` in the inferred schema before building `list_type`

## What this preserves

- `abstract_inverted_index` is stored as **raw JSON VARCHAR** (same as the snapshot pipeline and `openalex-core/conversion.rs`)
- `abstract` plain-text column is still computed by `oa_works_abstract_sql()` / `works_abstract_expr()`, which already reads the VARCHAR field via `map_entries()`
- Both columns are present in output parquet; `abstract_inverted_index` can be parsed with `jsonlite::fromJSON()` when needed

## Scope

Only `R/pro_request_parquet.R` (both `pro_request_parquet()` and `pro_request_parquet_R()`). The snapshot conversion path (`openalex-core/src/conversion.rs` → `convert_one_file`) already handled this correctly.

## Test plan

- [ ] Run `pro_request_parquet()` on a works query that returns records with `abstract_inverted_index` — conversion should complete without *"Duplicate name"* error
- [ ] Confirm output parquet contains both `abstract_inverted_index` (VARCHAR) and `abstract` (plain text) columns
- [ ] `devtools::check()` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)