### PR TITLE
chore: add Zenodo DOI badge to README and DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Version: 0.10.3
 Author: Rainer M Krug
 Maintainer: Rainer M Krug <Rainer@krugs.de>
 Description: More about what it does (maybe more than one line).
-URL: https://github.com/openalexPro/openalexPro, https://openalexpro.github.io/openalexPro/
+URL: https://github.com/openalexPro/openalexPro, https://openalexpro.github.io/openalexPro/, https://doi.org/10.5281/zenodo.17453180
 BugReports: https://github.com/openalexPro/openalexPro/issues
 License: GPL (>= 2)
 Depends:


### PR DESCRIPTION
Adds the concept DOI badge to README.md and DOI URL to DESCRIPTION.