### PR TITLE
Release v0.10.4

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -38,3 +38,4 @@
 ^src/Makevars$
 ^src/Makevars\.win$
 ^vignettes$
+^.lintr

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,8 @@
+linters: linters_with_defaults(
+    line_length_linter = line_length_linter(100L)
+  )
+exclusions: list(
+    "inst/scripts",
+    "tests/testthat/_snaps",
+    "tests/fixtures"
+  )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openalexPro
 Title: Providing a more advanced access to OpenAlex for the power user
-Version: 0.10.3
+Version: 0.10.4
 Author: Rainer M Krug
 Maintainer: Rainer M Krug <Rainer@krugs.de>
 Description: More about what it does (maybe more than one line).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,24 @@
-# openalexPro (development)
+# openalexPro 0.10.4
+
+## Internal / Code Quality
+
+* `pro_request_parquet()` refactored into small internal helpers
+  (`.prr_prepare_output`, `.prr_discover_jsons`, `.prr_infer_schema`,
+  `.prr_apply_baseline`, `.prr_fix_json_types`, `.prr_output_paths`,
+  `.prr_convert_one`) to drop cyclomatic complexity below the
+  `goodpractice` threshold. Behaviour is unchanged.
+
+* Added tests for `find_oas_binary()`, `run_oas()`,
+  `pro_validate_credentials()`, `prepare_snapshot()`, and
+  `sample_parquet_n()`. Package test coverage rose from ~73% to ~80%.
+
+* Tests that intentionally exercise the deprecated
+  `pro_request_jsonl_R()` / `pro_request_jsonl_parquet()` pipeline now
+  wrap those calls in `suppressWarnings()` to keep test output clean.
+
+* Added a `.lintr` configuration setting `line_length_linter(100)`
+  (modern tidyverse default) and reflowed remaining long lines in
+  package code.
 
 ## New Features
 

--- a/R/extract_doi.R
+++ b/R/extract_doi.R
@@ -3,19 +3,26 @@
 #' Extracts DOIs or specific DOI components (resolver, prefix, or suffix) from a character vector.
 #' Assumes that each element of `x` contains at most one DOI (with or without resolver).
 #'
-#' @param x A character vector potentially containing DOIs (e.g., raw DOIs, DOI URLs, or strings with embedded DOIs).
-#' @param non_doi_value Value to use for elements where no DOI or component is found. If `NULL`, only matched elements are returned.
-#' @param normalize Logical. If `TRUE` (default), convert extracted DOIs and suffixes to lowercase and trim surrounding whitespace. Has no effect for `what = "prefix"` or `what = "resolver"`.
+#' @param x A character vector potentially containing DOIs (e.g., raw DOIs,
+#'   DOI URLs, or strings with embedded DOIs).
+#' @param non_doi_value Value to use for elements where no DOI or component is
+#'   found. If `NULL`, only matched elements are returned.
+#' @param normalize Logical. If `TRUE` (default), convert extracted DOIs and
+#'   suffixes to lowercase and trim surrounding whitespace. Has no effect for
+#'   `what = "prefix"` or `what = "resolver"`.
 #' @param what What to extract from each element. One of:
 #' \describe{
-#'   \item{"doi"}{The full DOI name (prefix + "/" + suffix). Example: `"10.5281/zenodo.1234567"` (default)}
-#'   \item{"resolver"}{The resolver URL (e.g., `"https://doi.org/"`, `"http://dx.doi.org/"`) if present}
+#'   \item{"doi"}{The full DOI name (prefix + "/" + suffix). Example:
+#'     `"10.5281/zenodo.1234567"` (default)}
+#'   \item{"resolver"}{The resolver URL (e.g., `"https://doi.org/"`,
+#'     `"http://dx.doi.org/"`) if present}
 #'   \item{"prefix"}{The DOI prefix only (e.g., `"10.5281"`)}
 #'   \item{"suffix"}{The DOI suffix only (e.g., `"zenodo.1234567"`)}
 #' }
 #'
 #' @return A character vector:
-#'   - If `non_doi_value` is not `NULL`, a vector of the same length as `x`, with unmatched entries replaced.
+#'   - If `non_doi_value` is not `NULL`, a vector of the same length as `x`,
+#'     with unmatched entries replaced.
 #'   - If `non_doi_value` is `NULL`, a vector of only matched entries.
 #'
 #' @examples

--- a/R/opt_api_key.R
+++ b/R/opt_api_key.R
@@ -1,6 +1,7 @@
 #' Get API key for OpenAlex API
 #'
-#' @param api_key character vector or NULL. If specified, value to assign to the api key option. Default is `NULL`.
+#' @param api_key character vector or NULL. If specified, value to assign to
+#'   the api key option. Default is `NULL`.
 #' @return The API key, if `api_key` is not specified the current one, otherwise the old one.
 #'
 #' @export

--- a/R/opt_select_fields.R
+++ b/R/opt_select_fields.R
@@ -24,7 +24,8 @@ opt_select_fields <- function(update = FALSE) {
     select <- select[[1]][-1]
 
     ## <<
-    ## This is to make sure that `id` is in the filter list, which it is not at the moment, but always present.
+    ## Ensure `id` is in the filter list: it is not returned at the moment
+    ## but is always present in responses.
 
     if (!("id" %in% select)) {
       select <- c("id", select)

--- a/R/prepare_snapshot.R
+++ b/R/prepare_snapshot.R
@@ -53,7 +53,10 @@ makefile_dst <- file.path(path, "Makefile")
 
   # Copy Makefile
   if (file.exists(makefile_dst) && !overwrite) {
-    cli::cli_alert_warning("Makefile already exists at {.path {makefile_dst}}. Use {.arg overwrite = TRUE} to replace.")
+    cli::cli_alert_warning(c(
+      "Makefile already exists at {.path {makefile_dst}}. ",
+      "Use {.arg overwrite = TRUE} to replace."
+    ))
   } else {
     file.copy(makefile_src, makefile_dst, overwrite = overwrite)
     cli::cli_alert_success("Copied Makefile to {.path {makefile_dst}}")
@@ -62,7 +65,10 @@ makefile_dst <- file.path(path, "Makefile")
   # Copy vignette HTML if it exists
   if (file.exists(vignette_src)) {
     if (file.exists(vignette_dst) && !overwrite) {
-      cli::cli_alert_warning("Documentation already exists at {.path {vignette_dst}}. Use {.arg overwrite = TRUE} to replace.")
+      cli::cli_alert_warning(c(
+        "Documentation already exists at {.path {vignette_dst}}. ",
+        "Use {.arg overwrite = TRUE} to replace."
+      ))
     } else {
       file.copy(vignette_src, vignette_dst, overwrite = overwrite)
       cli::cli_alert_success("Copied documentation to {.path {vignette_dst}}")

--- a/R/pro_api_key.R
+++ b/R/pro_api_key.R
@@ -30,7 +30,7 @@
 #' \code{\link[base:Sys.getenv]{Sys.getenv}}
 #'
 #' @export
-pro_api_key = function() {
+pro_api_key <- function() {
   api_key <- opt_api_key()
   if (is.null(api_key)) {
     api_key <- Sys.getenv("openalexPro.api_key")

--- a/R/pro_download_content.R
+++ b/R/pro_download_content.R
@@ -83,7 +83,8 @@
 #' }
 #'
 #' @export
-#' @importFrom httr2 request req_url_query req_user_agent req_perform resp_body_raw resp_body_string resp_status
+#' @importFrom httr2 request req_url_query req_user_agent req_perform
+#' @importFrom httr2 resp_body_raw resp_body_string resp_status
 #' @importFrom future plan multisession sequential
 #' @importFrom future.apply future_lapply
 #' @importFrom progressr with_progress progressor handlers

--- a/R/pro_query.R
+++ b/R/pro_query.R
@@ -137,8 +137,14 @@
   search_filters <- grep("\\.search(\\.no_stem)?$", names(fl), value = TRUE)
   if (length(search_filters)) {
     cli::cli_warn(c(
-      "!" = "The filter argument{?s} {.val {search_filters}} use{?s/} the deprecated {.code field.search} syntax.",
-      "i" = "Use the {.arg search} parameter instead: {.code pro_query(..., search = \"your terms\")}.",
+      "!" = paste0(
+        "The filter argument{?s} {.val {search_filters}} use{?s/} the ",
+        "deprecated {.code field.search} syntax."
+      ),
+      "i" = paste0(
+        "Use the {.arg search} parameter instead: ",
+        "{.code pro_query(..., search = \"your terms\")}."
+      ),
       "i" = "See {.url https://developers.openalex.org/guides/searching} for details."
     ))
   }

--- a/R/pro_request_parquet.R
+++ b/R/pro_request_parquet.R
@@ -95,11 +95,78 @@ pro_request_parquet <- function(
   enrich = TRUE,
   schema = "auto"
 ) {
-  # ── Argument checks ──────────────────────────────────────────────────────────
   if (is.null(input_json)) stop("No `input_json` specified!")
   if (is.null(output))     stop("No `output` specified!")
 
-  # ── Output directory ─────────────────────────────────────────────────────────
+  progress_file <- .prr_prepare_output(output, overwrite)
+  success <- FALSE
+  on.exit({ if (isTRUE(success)) unlink(progress_file) }, add = TRUE)
+
+  disc      <- .prr_discover_jsons(input_json)
+  schema_df <- .prr_infer_schema(
+    disc$jsons, disc$array_field, sample_size, schema, verbose
+  )
+  list_type <- attr(schema_df, "list_type")
+
+  present_cols <- if (!is.null(schema_df)) schema_df$column_name else character(0L)
+  abstract_sql <- if (enrich && "abstract_inverted_index" %in% present_cols) {
+    oa_works_abstract_sql()
+  } else NULL
+  citation_sql <- if (enrich && all(c("authorships", "publication_year") %in% present_cols)) {
+    oa_works_citation_sql()
+  } else NULL
+
+  output_files <- .prr_output_paths(disc$jsons, input_json, output)
+
+  if (!is.null(workers) && workers > 1L) {
+    old_plan <- future::plan(future::multisession, workers = workers)
+    on.exit(future::plan(old_plan), add = TRUE)
+  }
+
+  if (progress) {
+    cli::cli_alert_info("Converting {length(disc$jsons)} JSON file{?s} to Parquet")
+    progressr::handlers("cli")
+  }
+
+  .array_field  <- disc$array_field
+  .has_subdirs  <- disc$has_subdirs
+  .list_type    <- list_type
+  .abstract_sql <- abstract_sql
+  .citation_sql <- citation_sql
+  .add_columns  <- add_columns
+  .verbose      <- verbose
+  jsons         <- disc$jsons
+
+  progressr::with_progress({
+    p <- if (progress) progressr::progressor(steps = length(jsons)) else NULL
+    future.apply::future_lapply(seq_along(jsons), function(i) {
+      .prr_convert_one(
+        fn           = jsons[[i]],
+        out_fn       = output_files[[i]],
+        array_field  = .array_field,
+        has_subdirs  = .has_subdirs,
+        list_type    = .list_type,
+        abstract_sql = .abstract_sql,
+        citation_sql = .citation_sql,
+        add_columns  = .add_columns,
+        verbose      = .verbose
+      )
+      if (!is.null(p)) p()
+      invisible(NULL)
+    })
+  }, enable = progress)
+
+  if (delete_input) unlink(input_json, recursive = TRUE, force = TRUE)
+
+  success <- TRUE
+  invisible(normalizePath(output))
+}
+
+# Helpers --------------------------------------------------------------------
+
+#' @keywords internal
+#' @noRd
+.prr_prepare_output <- function(output, overwrite) {
   if (file.exists(output)) {
     if (!overwrite) {
       stop(
@@ -112,21 +179,20 @@ pro_request_parquet <- function(
   dir.create(output, recursive = TRUE, showWarnings = FALSE)
   progress_file <- file.path(output, "00_in.progress")
   file.create(progress_file)
-  success <- FALSE
-  on.exit({ if (isTRUE(success)) unlink(progress_file) }, add = TRUE)
+  progress_file
+}
 
-  # ── Discover JSON files ──────────────────────────────────────────────────────
+#' @keywords internal
+#' @noRd
+.prr_discover_jsons <- function(input_json) {
   jsons <- list.files(
     input_json, pattern = "\\.json$", full.names = TRUE, recursive = TRUE
   )
-  # Sort by trailing page number so pages convert in order
   jsons <- jsons[order(as.numeric(
     sub(".*_([0-9]+)\\.json$", "\\1", jsons)
   ))]
   if (length(jsons) == 0) stop("No JSON files found in `input_json`!")
-  has_subdirs <- length(list.dirs(input_json, recursive = FALSE)) > 0
 
-  # Determine format from filename prefix
   types <- unique(vapply(
     basename(jsons),
     function(b) strsplit(b, "_")[[1L]][1L],
@@ -134,273 +200,204 @@ pro_request_parquet <- function(
   ))
   if (length(types) > 1L) stop("Mixed entity types found in `input_json`!")
   entity_type <- if (identical(types, "group")) "group_by" else types
-  # array_field: the JSON key containing the records array; NULL for single records
-  array_field <- switch(entity_type, results = "results", group_by = "group_by", NULL)
+  array_field <- switch(
+    entity_type, results = "results", group_by = "group_by", NULL
+  )
 
-  # ── Schema inference ─────────────────────────────────────────────────────────
+  list(
+    jsons       = jsons,
+    array_field = array_field,
+    has_subdirs = length(list.dirs(input_json, recursive = FALSE)) > 0
+  )
+}
+
+#' @keywords internal
+#' @noRd
+.prr_infer_schema <- function(jsons, array_field, sample_size, schema, verbose) {
   sample_opt <- if (isTRUE(sample_size > 0)) {
     sprintf(", sample_size = %d", as.integer(sample_size))
   } else {
     ""
   }
-  # Use at most 20 files for inference to keep it fast
   infer_files <- if (length(jsons) > 20L) sample(jsons, 20L) else jsons
   files_sql   <- paste0("[", paste0("'", infer_files, "'", collapse = ", "), "]")
-
-  schema_df <- NULL
-  list_type <- NULL  # STRUCT(...)[] type for the array items
 
   if (verbose) message("Inferring schema from ", length(infer_files), " sampled file(s)...")
 
   con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
   DBI::dbExecute(con, "INSTALL json; LOAD json;")
 
-  if (!is.null(array_field)) {
-    # Paginated case: {"results":[...], "meta":{...}}
-    # ignore_errors=true: OpenAlex works abstract_inverted_index can contain
-    # duplicate struct keys (e.g. "the"/"The"); DuckDB struct auto-detection
-    # rejects these.  With ignore_errors=true DuckDB infers
-    # abstract_inverted_index as MAP(VARCHAR, BIGINT[]) which handles duplicate
-    # keys correctly and works with map_entries() in oa_works_abstract_sql().
-    schema_sql <- sprintf(
-      "DESCRIBE SELECT r.* FROM (SELECT unnest(%s) AS r FROM read_json(%s, ignore_errors = true%s))",
-      array_field, files_sql, sample_opt
-    )
-    schema_df <- tryCatch(
-      DBI::dbGetQuery(con, schema_sql),
-      error = function(e) {
-        if (verbose) message("Schema inference failed: ", conditionMessage(e))
-        NULL
-      }
-    )
-    if (!is.null(schema_df) && nrow(schema_df) > 0L) {
-      # Force abstract_inverted_index to MAP(VARCHAR, BIGINT[]).
-      # When a sampled page has no duplicate-cased keys DuckDB infers the
-      # column as STRUCT(...) rather than MAP, which breaks map_entries() in
-      # oa_works_abstract_sql().  Pinning the type here ensures read_json()
-      # always parses it as MAP regardless of the sample contents.
-      aii_idx <- which(schema_df$column_name == "abstract_inverted_index")
-      if (length(aii_idx) == 1L) {
-        schema_df$column_type[aii_idx] <- "MAP(VARCHAR, BIGINT[])"
-      }
-
-      # ── Baseline schema type resolution ─────────────────────────────────────
-      # Load a high-quality pre-built schema (inferred from millions of snapshot
-      # records) and override any column type where DuckDB runtime inference
-      # fell back to the ambiguous JSON type.  Runtime inference remains the
-      # source of truth for *which columns are present*; the baseline only
-      # corrects *types* for columns it knows about.
-      #
-      # JSON / JSON[] types arise when all sampled records have null values for
-      # a field — DuckDB cannot infer the specific type and uses JSON as a
-      # catch-all.  When multiple pro_request_parquet() calls produce parquet
-      # files that are later read with union_by_name = true, this mismatch
-      # causes "Can't change source type (VARCHAR[]) to target type (JSON)".
-      if (!is.null(schema) && !identical(schema, "none")) {
-        baseline_df <- .resolve_baseline(schema, present_cols = schema_df$column_name)
-        if (!is.null(baseline_df)) {
-          for (.i in seq_len(nrow(schema_df))) {
-            rt  <- schema_df$column_type[.i]
-            # Override only when runtime produced an ambiguous JSON type —
-            # clean types like VARCHAR[], STRUCT(...) reflect actual data and
-            # must not be replaced by a potentially older baseline type.
-            if (grepl("\\bJSON\\b", rt)) {
-              col <- schema_df$column_name[.i]
-              base_row <- baseline_df[baseline_df$col_name == col, , drop = FALSE]
-              if (nrow(base_row) == 1L) {
-                schema_df$column_type[.i] <- base_row$col_type
-              }
-            }
-          }
-          if (verbose) {
-            message(
-              "Applied baseline schema for entity '",
-              attr(baseline_df, "entity"), "'."
-            )
-          }
-        }
-      }
-      # ────────────────────────────────────────────────────────────────────────
-
-      struct_fields <- paste(schema_df$column_name, schema_df$column_type, sep = " ")
-      list_type <- paste0(
-        "STRUCT(", paste(struct_fields, collapse = ", "), ")[]"
-      )
-      # Normalise OpenAlex source-struct fields that DuckDB infers as JSON
-      # when all sampled records have null values for those fields.  Using
-      # JSON as a scalar type for what is actually VARCHAR[] (e.g. "issn")
-      # causes read_parquet(union_by_name=true) to fail with
-      # "Can't change source type (VARCHAR[]) to target type (JSON)" when
-      # another page file correctly inferred the field as VARCHAR[].
-      #
-      # Fix: replace the known OpenAlex field types that DuckDB may wrongly
-      # infer as JSON / JSON[] with their correct specific types.
-      list_type <- gsub(
-        "\\bissn_l JSON\\b", "issn_l VARCHAR",  list_type
-      )
-      list_type <- gsub(
-        "(?<![_])\\bissn JSON\\b", "issn VARCHAR[]", list_type, perl = TRUE
-      )
-      list_type <- gsub(
-        "host_organization_lineage_names JSON\\[\\]",
-        "host_organization_lineage_names VARCHAR[]",
-        list_type, fixed = TRUE
-      )
-    }
-  } else {
-    # Single-record case: bare JSON object.
+  if (is.null(array_field)) {
     schema_sql <- sprintf(
       "DESCRIBE SELECT * FROM read_json(%s, ignore_errors = true%s)",
       files_sql, sample_opt
     )
-    schema_df <- tryCatch(
-      DBI::dbGetQuery(con, schema_sql),
-      error = function(e) NULL
-    )
+    schema_df <- tryCatch(DBI::dbGetQuery(con, schema_sql), error = function(e) NULL)
+    return(schema_df)
   }
 
-  DBI::dbDisconnect(con, shutdown = TRUE)
+  schema_sql <- sprintf(
+    "DESCRIBE SELECT r.* FROM (SELECT unnest(%s) AS r FROM read_json(%s, ignore_errors = true%s))",
+    array_field, files_sql, sample_opt
+  )
+  schema_df <- tryCatch(
+    DBI::dbGetQuery(con, schema_sql),
+    error = function(e) {
+      if (verbose) message("Schema inference failed: ", conditionMessage(e))
+      NULL
+    }
+  )
+  if (is.null(schema_df) || nrow(schema_df) == 0L) return(schema_df)
 
-  # Decide which enrichment columns to add
-  present_cols  <- if (!is.null(schema_df)) schema_df$column_name else character(0L)
-  add_abstract  <- enrich && "abstract_inverted_index" %in% present_cols
-  add_citation  <- enrich && all(c("authorships", "publication_year") %in% present_cols)
+  # Force abstract_inverted_index to MAP — DuckDB sometimes infers STRUCT
+  # when the sample has no duplicate-cased keys, which breaks map_entries().
+  aii_idx <- which(schema_df$column_name == "abstract_inverted_index")
+  if (length(aii_idx) == 1L) {
+    schema_df$column_type[aii_idx] <- "MAP(VARCHAR, BIGINT[])"
+  }
 
-  abstract_sql <- if (add_abstract) oa_works_abstract_sql() else NULL
-  citation_sql <- if (add_citation) oa_works_citation_sql() else NULL
+  schema_df <- .prr_apply_baseline(schema_df, schema, verbose)
 
-  # ── Compute output file paths ─────────────────────────────────────────────────
+  struct_fields <- paste(schema_df$column_name, schema_df$column_type, sep = " ")
+  list_type <- paste0("STRUCT(", paste(struct_fields, collapse = ", "), ")[]")
+  list_type <- .prr_fix_json_types(list_type)
+  attr(schema_df, "list_type") <- list_type
+  schema_df
+}
+
+#' @keywords internal
+#' @noRd
+.prr_apply_baseline <- function(schema_df, schema, verbose) {
+  if (is.null(schema) || identical(schema, "none")) return(schema_df)
+  baseline_df <- .resolve_baseline(schema, present_cols = schema_df$column_name)
+  if (is.null(baseline_df)) return(schema_df)
+
+  for (.i in seq_len(nrow(schema_df))) {
+    rt <- schema_df$column_type[.i]
+    if (!grepl("\\bJSON\\b", rt)) next
+    col      <- schema_df$column_name[.i]
+    base_row <- baseline_df[baseline_df$col_name == col, , drop = FALSE]
+    if (nrow(base_row) == 1L) {
+      schema_df$column_type[.i] <- base_row$col_type
+    }
+  }
+  if (verbose) {
+    message(
+      "Applied baseline schema for entity '",
+      attr(baseline_df, "entity"), "'."
+    )
+  }
+  schema_df
+}
+
+#' @keywords internal
+#' @noRd
+.prr_fix_json_types <- function(list_type) {
+  # Patch known OpenAlex source-struct fields DuckDB may infer as JSON when
+  # all sampled values are null — required for union_by_name = true reads.
+  list_type <- gsub("\\bissn_l JSON\\b", "issn_l VARCHAR", list_type)
+  list_type <- gsub("(?<![_])\\bissn JSON\\b", "issn VARCHAR[]", list_type, perl = TRUE)
+  gsub(
+    "host_organization_lineage_names JSON\\[\\]",
+    "host_organization_lineage_names VARCHAR[]",
+    list_type, fixed = TRUE
+  )
+}
+
+#' @keywords internal
+#' @noRd
+.prr_output_paths <- function(jsons, input_json, output) {
   input_depth <- length(strsplit(gsub("\\\\", "/", input_json), "/")[[1L]])
-  hive_key    <- function(depth) if (depth == 1L) "query" else paste0("query_l", depth)
+  hive_key <- function(depth) if (depth == 1L) "query" else paste0("query_l", depth)
 
-  output_files <- vapply(jsons, function(f) {
-    f_parts   <- strsplit(gsub("\\\\", "/", f), "/")[[1L]]
-    fname     <- sub("\\.json$", ".parquet", basename(f))
+  vapply(jsons, function(f) {
+    f_parts <- strsplit(gsub("\\\\", "/", f), "/")[[1L]]
+    fname   <- sub("\\.json$", ".parquet", basename(f))
     rel_parts <- if (length(f_parts) > input_depth + 1L) {
       f_parts[seq(input_depth + 1L, length(f_parts) - 1L)]
     } else {
       character(0L)
     }
-    if (length(rel_parts) > 0L) {
-      hive_dirs <- mapply(
-        function(d, v) paste0(hive_key(d), "=", v),
-        seq_along(rel_parts), rel_parts,
-        SIMPLIFY = TRUE
-      )
-      do.call(file.path, c(list(output), as.list(hive_dirs), list(fname)))
-    } else {
-      file.path(output, fname)
-    }
+    if (length(rel_parts) == 0L) return(file.path(output, fname))
+    hive_dirs <- mapply(
+      function(d, v) paste0(hive_key(d), "=", v),
+      seq_along(rel_parts), rel_parts,
+      SIMPLIFY = TRUE
+    )
+    do.call(file.path, c(list(output), as.list(hive_dirs), list(fname)))
   }, character(1L), USE.NAMES = FALSE)
+}
 
-  # ── Parallel conversion ───────────────────────────────────────────────────────
-  if (!is.null(workers) && workers > 1L) {
-    old_plan <- future::plan(future::multisession, workers = workers)
-    on.exit(future::plan(old_plan), add = TRUE)
+#' @keywords internal
+#' @noRd
+.prr_convert_one <- function(
+  fn, out_fn, array_field, has_subdirs, list_type,
+  abstract_sql, citation_sql, add_columns, verbose
+) {
+  pn <- if (has_subdirs) {
+    basename(dirname(fn))
+  } else {
+    sub(".*_([0-9]+)\\.json$", "\\1", basename(fn))
+  }
+  dir.create(dirname(out_fn), recursive = TRUE, showWarnings = FALSE)
+
+  extras <- character(0L)
+  if (!is.null(abstract_sql)) extras <- c(extras, paste0(abstract_sql, " AS abstract"))
+  if (!is.null(citation_sql)) extras <- c(extras, paste0(citation_sql, " AS citation"))
+  extras <- c(extras, sprintf("'%s' AS page", pn))
+  if (length(add_columns) > 0L) {
+    extras <- c(
+      extras,
+      sprintf("'%s' AS %s", as.character(add_columns), names(add_columns))
+    )
+  }
+  extra_select <- if (length(extras) > 0L) {
+    paste(",", paste(extras, collapse = ",\n          "))
+  } else {
+    ""
   }
 
-  if (progress) {
-    cli::cli_alert_info("Converting {length(jsons)} JSON file{?s} to Parquet")
-    progressr::handlers("cli")
-  }
-
-  # Capture all loop-invariant state as plain values for future serialisation
-  .array_field  <- array_field
-  .list_type    <- list_type
-  .abstract_sql <- abstract_sql
-  .citation_sql <- citation_sql
-  .add_columns  <- add_columns
-  .has_subdirs  <- has_subdirs
-  .verbose      <- verbose
-
-  progressr::with_progress({
-    p <- if (progress) progressr::progressor(steps = length(jsons)) else NULL
-
-    future.apply::future_lapply(seq_along(jsons), function(i) {
-      fn     <- jsons[[i]]
-      out_fn <- output_files[[i]]
-
-      # Page identifier: subdirectory name for multi-query inputs, else number
-      pn <- if (.has_subdirs) {
-        basename(dirname(fn))
-      } else {
-        sub(".*_([0-9]+)\\.json$", "\\1", basename(fn))
-      }
-
-      dir.create(dirname(out_fn), recursive = TRUE, showWarnings = FALSE)
-
-      # Build the list of extra SELECT expressions
-      extras <- character(0L)
-      if (!is.null(.abstract_sql)) {
-        extras <- c(extras, paste0(.abstract_sql, " AS abstract"))
-      }
-      if (!is.null(.citation_sql)) {
-        extras <- c(extras, paste0(.citation_sql, " AS citation"))
-      }
-      extras <- c(extras, sprintf("'%s' AS page", pn))
-      if (length(.add_columns) > 0L) {
-        extras <- c(
-          extras,
-          sprintf("'%s' AS %s", as.character(.add_columns), names(.add_columns))
-        )
-      }
-      extra_select <- if (length(extras) > 0L) {
-        paste(",", paste(extras, collapse = ",\n          "))
-      } else {
-        ""
-      }
-
-      # Build conversion SQL depending on format
-      sql <- if (!is.null(.array_field)) {
-        read_spec <- if (!is.null(.list_type)) {
-          sprintf(
-            "read_json('%s', columns = {'%s': '%s', 'meta': 'JSON'})",
-            fn, .array_field, .list_type
-          )
-        } else {
-          sprintf("read_json_auto('%s')", fn)
-        }
-        sprintf(
-          "COPY (
-            SELECT *%s
-            FROM (
-              SELECT r.*
-              FROM (SELECT unnest(%s) AS r FROM %s)
-            )
-          ) TO '%s' (FORMAT PARQUET, COMPRESSION SNAPPY, ROW_GROUP_SIZE 100000)",
-          extra_select, .array_field, read_spec, out_fn
-        )
-      } else {
-        sprintf(
-          "COPY (
-            SELECT *%s
-            FROM read_json_auto('%s')
-          ) TO '%s' (FORMAT PARQUET, COMPRESSION SNAPPY, ROW_GROUP_SIZE 100000)",
-          extra_select, fn, out_fn
-        )
-      }
-
-      worker_con <- DBI::dbConnect(duckdb::duckdb())
-      tryCatch(
-        {
-          DBI::dbExecute(worker_con, "INSTALL json; LOAD json;")
-          DBI::dbExecute(worker_con, sql)
-        },
-        error = function(e) {
-          if (.verbose) {
-            message("Failed to convert ", basename(fn), ": ", conditionMessage(e))
-          }
-        }
+  sql <- if (!is.null(array_field)) {
+    read_spec <- if (!is.null(list_type)) {
+      sprintf(
+        "read_json('%s', columns = {'%s': '%s', 'meta': 'JSON'})",
+        fn, array_field, list_type
       )
-      DBI::dbDisconnect(worker_con, shutdown = TRUE)
+    } else {
+      sprintf("read_json_auto('%s')", fn)
+    }
+    sprintf(
+      "COPY (
+        SELECT *%s
+        FROM (
+          SELECT r.*
+          FROM (SELECT unnest(%s) AS r FROM %s)
+        )
+      ) TO '%s' (FORMAT PARQUET, COMPRESSION SNAPPY, ROW_GROUP_SIZE 100000)",
+      extra_select, array_field, read_spec, out_fn
+    )
+  } else {
+    sprintf(
+      "COPY (
+        SELECT *%s
+        FROM read_json_auto('%s')
+      ) TO '%s' (FORMAT PARQUET, COMPRESSION SNAPPY, ROW_GROUP_SIZE 100000)",
+      extra_select, fn, out_fn
+    )
+  }
 
-      if (!is.null(p)) p()
-      invisible(NULL)
-    })
-  }, enable = progress)
-
-  if (delete_input) unlink(input_json, recursive = TRUE, force = TRUE)
-
-  success <- TRUE
-  invisible(normalizePath(output))
+  worker_con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(worker_con, shutdown = TRUE), add = TRUE)
+  tryCatch(
+    {
+      DBI::dbExecute(worker_con, "INSTALL json; LOAD json;")
+      DBI::dbExecute(worker_con, sql)
+    },
+    error = function(e) {
+      if (verbose) {
+        message("Failed to convert ", basename(fn), ": ", conditionMessage(e))
+      }
+    }
+  )
 }

--- a/man/extract_doi.Rd
+++ b/man/extract_doi.Rd
@@ -12,23 +12,30 @@ extract_doi(
 )
 }
 \arguments{
-\item{x}{A character vector potentially containing DOIs (e.g., raw DOIs, DOI URLs, or strings with embedded DOIs).}
+\item{x}{A character vector potentially containing DOIs (e.g., raw DOIs,
+DOI URLs, or strings with embedded DOIs).}
 
-\item{non_doi_value}{Value to use for elements where no DOI or component is found. If `NULL`, only matched elements are returned.}
+\item{non_doi_value}{Value to use for elements where no DOI or component is
+found. If `NULL`, only matched elements are returned.}
 
-\item{normalize}{Logical. If `TRUE` (default), convert extracted DOIs and suffixes to lowercase and trim surrounding whitespace. Has no effect for `what = "prefix"` or `what = "resolver"`.}
+\item{normalize}{Logical. If `TRUE` (default), convert extracted DOIs and
+suffixes to lowercase and trim surrounding whitespace. Has no effect for
+`what = "prefix"` or `what = "resolver"`.}
 
 \item{what}{What to extract from each element. One of:
 \describe{
-  \item{"doi"}{The full DOI name (prefix + "/" + suffix). Example: `"10.5281/zenodo.1234567"` (default)}
-  \item{"resolver"}{The resolver URL (e.g., `"https://doi.org/"`, `"http://dx.doi.org/"`) if present}
+  \item{"doi"}{The full DOI name (prefix + "/" + suffix). Example:
+    `"10.5281/zenodo.1234567"` (default)}
+  \item{"resolver"}{The resolver URL (e.g., `"https://doi.org/"`,
+    `"http://dx.doi.org/"`) if present}
   \item{"prefix"}{The DOI prefix only (e.g., `"10.5281"`)}
   \item{"suffix"}{The DOI suffix only (e.g., `"zenodo.1234567"`)}
 }}
 }
 \value{
 A character vector:
-  - If `non_doi_value` is not `NULL`, a vector of the same length as `x`, with unmatched entries replaced.
+  - If `non_doi_value` is not `NULL`, a vector of the same length as `x`,
+    with unmatched entries replaced.
   - If `non_doi_value` is `NULL`, a vector of only matched entries.
 }
 \description{

--- a/man/opt_api_key.Rd
+++ b/man/opt_api_key.Rd
@@ -7,7 +7,8 @@
 opt_api_key(api_key)
 }
 \arguments{
-\item{api_key}{character vector or NULL. If specified, value to assign to the api key option. Default is `NULL`.}
+\item{api_key}{character vector or NULL. If specified, value to assign to
+the api key option. Default is `NULL`.}
 }
 \value{
 The API key, if `api_key` is not specified the current one, otherwise the old one.

--- a/tests/testthat/test-004-pro_pipeline_single.R
+++ b/tests/testthat/test-004-pro_pipeline_single.R
@@ -35,12 +35,14 @@ test_that("pro_request single identifier", {
 
 test_that("pro_request_jsonl_R single identifier", {
   # Convert to jsonl
-  output_jsonl <- output_json |>
-    pro_request_jsonl_R(
-      output = output_jsonl,
-      verbose = FALSE,
-      progress = TRUE
-    )
+  output_jsonl <- suppressWarnings(
+    output_json |>
+      pro_request_jsonl_R(
+        output = output_jsonl,
+        verbose = FALSE,
+        progress = TRUE
+      )
+  )
 
   # Check that the output file contains the expected data (platform-agnostic)
   expect_snapshot_file(
@@ -52,11 +54,13 @@ test_that("pro_request_jsonl_R single identifier", {
 
 test_that("pro_request_jsonl_parquet single identifier", {
   # Convert to parquet
-  output_parquet <- output_jsonl |>
-    pro_request_jsonl_parquet(
-      output = output_parquet,
-      verbose = FALSE
-    )
+  output_parquet <- suppressWarnings(
+    output_jsonl |>
+      pro_request_jsonl_parquet(
+        output = output_parquet,
+        verbose = FALSE
+      )
+  )
 
   # Check that the output file exists
   expect_true(

--- a/tests/testthat/test-005-pro_pipeline_search.R
+++ b/tests/testthat/test-005-pro_pipeline_search.R
@@ -38,12 +38,14 @@ test_that("pro_request search `biodiversity AND fiance`", {
 
 test_that("pro_request_jsonl_R search `biodiversity AND finance`", {
   # Convert to jsonl
-  output_jsonl <- output_json |>
-    pro_request_jsonl_R(
-      output = output_jsonl,
-      verbose = FALSE,
-      progress = TRUE
-    )
+  output_jsonl <- suppressWarnings(
+    output_json |>
+      pro_request_jsonl_R(
+        output = output_jsonl,
+        verbose = FALSE,
+        progress = TRUE
+      )
+  )
 
   # Check that the output file contains the expected data (platform-agnostic)
   expect_snapshot_file(
@@ -55,11 +57,13 @@ test_that("pro_request_jsonl_R search `biodiversity AND finance`", {
 
 test_that("pro_request_jsonl_parquet search `biodiversity AND finance`", {
   # Convert to parquet
-  output_parquet <- output_jsonl |>
-    pro_request_jsonl_parquet(
-      output = output_parquet,
-      verbose = FALSE
-    )
+  output_parquet <- suppressWarnings(
+    output_jsonl |>
+      pro_request_jsonl_parquet(
+        output = output_parquet,
+        verbose = FALSE
+      )
+  )
 
   # Check that the output file exists
   expect_true(

--- a/tests/testthat/test-007-pro_pipeline_group_by.R
+++ b/tests/testthat/test-007-pro_pipeline_group_by.R
@@ -41,12 +41,14 @@ test_that("pro_request `biodiversity` and group by `type`", {
 
 test_that("pro_request_jsonl_R `biodiversity` and group by type", {
   # Convert to jsonl
-  output_jsonl <- output_json |>
-    pro_request_jsonl_R(
-      output = output_jsonl,
-      verbose = FALSE,
-      progress = TRUE
-    )
+  output_jsonl <- suppressWarnings(
+    output_json |>
+      pro_request_jsonl_R(
+        output = output_jsonl,
+        verbose = FALSE,
+        progress = TRUE
+      )
+  )
 
   # Check that the output file contains the expected data (platform-agnostic)
   expect_snapshot_file(
@@ -58,11 +60,13 @@ test_that("pro_request_jsonl_R `biodiversity` and group by type", {
 
 test_that("pro_request_jsonl_parquet `biodiversity` and group by type", {
   # Convert to parquet
-  output_parquet <- output_jsonl |>
-    pro_request_jsonl_parquet(
-      output = output_parquet,
-      verbose = FALSE
-    )
+  output_parquet <- suppressWarnings(
+    output_jsonl |>
+      pro_request_jsonl_parquet(
+        output = output_parquet,
+        verbose = FALSE
+      )
+  )
 
   # Check that the output file exists
   expect_true(

--- a/tests/testthat/test-008-pro_pipeline_parallel.R
+++ b/tests/testthat/test-008-pro_pipeline_parallel.R
@@ -72,12 +72,14 @@ test_that("pro_request with url list  and parallel", {
 
 test_that("pro_request_jsonl_R with subfolders", {
   # Convert to jsonl
-  output_jsonl <- output_json |>
-    pro_request_jsonl_R(
-      output = output_jsonl,
-      verbose = FALSE,
-      progress = TRUE
-    )
+  output_jsonl <- suppressWarnings(
+    output_json |>
+      pro_request_jsonl_R(
+        output = output_jsonl,
+        verbose = FALSE,
+        progress = TRUE
+      )
+  )
 
   # Check that the output file contains the expected data
   # Sort to ensure consistent ordering across platforms
@@ -99,11 +101,13 @@ test_that("pro_request_jsonl_R with subfolders", {
 
 test_that("pro_request_jsonl_parquet with subfolders", {
   # Convert to parquet
-  output_parquet <- output_jsonl |>
-    pro_request_jsonl_parquet(
-      output = output_parquet,
-      verbose = FALSE
-    )
+  output_parquet <- suppressWarnings(
+    output_jsonl |>
+      pro_request_jsonl_parquet(
+        output = output_parquet,
+        verbose = FALSE
+      )
+  )
 
   # Check that the output file exists
   expect_true(

--- a/tests/testthat/test-009-pro_pipeline_nested.R
+++ b/tests/testthat/test-009-pro_pipeline_nested.R
@@ -80,11 +80,11 @@ test_that("pro_request_jsonl_parquet: two-level hive partitioning", {
   make_minimal_jsonl(file.path(base_jsonl, "grp_a", "sub_y", "results_page_1.json"), page = 1L)
   make_minimal_jsonl(file.path(base_jsonl, "grp_b",          "results_page_1.json"), page = 1L)
 
-  out <- pro_request_jsonl_parquet(
+  out <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = base_jsonl,
     output = base_parquet,
     verbose = FALSE
-  )
+  ))
 
   parquet_files <- sort(list.files(out, "*.parquet", recursive = TRUE))
 
@@ -110,11 +110,11 @@ test_that("pro_request_jsonl_parquet: single-level hive partitioning unchanged",
   make_minimal_jsonl(file.path(base_jsonl, "chunk_1", "results_page_1.json"), page = 1L)
   make_minimal_jsonl(file.path(base_jsonl, "chunk_2", "results_page_1.json"), page = 1L)
 
-  out <- pro_request_jsonl_parquet(
+  out <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = base_jsonl,
     output = base_parquet,
     verbose = FALSE
-  )
+  ))
 
   parquet_files <- sort(list.files(out, "*.parquet", recursive = TRUE))
   expect_true(any(grepl("^query=chunk_1/", parquet_files)))
@@ -165,12 +165,12 @@ test_that("pro_request with nested list creates nested output dirs", {
 })
 
 test_that("pro_request_jsonl_R with nested subdirs", {
-  out <- pro_request_jsonl_R(
+  out <- suppressWarnings(pro_request_jsonl_R(
     input  = output_json_nested,
     output = output_jsonl_nested,
     verbose = FALSE,
     progress = TRUE
-  )
+  ))
 
   jsonl_files <- sort(list.files(output_jsonl_nested, "*.json", recursive = TRUE))
   expect_true(all(grepl("^grp_[ab]/", jsonl_files)))
@@ -178,11 +178,11 @@ test_that("pro_request_jsonl_R with nested subdirs", {
 })
 
 test_that("pro_request_jsonl_parquet with nested subdirs produces hive partitions", {
-  out <- pro_request_jsonl_parquet(
+  out <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = output_jsonl_nested,
     output      = output_parquet_nested,
     verbose     = FALSE
-  )
+  ))
 
   parquet_files <- sort(list.files(out, "*.parquet", recursive = TRUE))
   expect_true(any(grepl("^query=grp_a/query_l2=", parquet_files)))

--- a/tests/testthat/test-010-schema_harmonization.R
+++ b/tests/testthat/test-010-schema_harmonization.R
@@ -25,12 +25,12 @@ test_that("schema harmonization prevents read errors from type conflicts", {
   if (dir.exists(output_parquet)) unlink(output_parquet, recursive = TRUE)
 
   # Convert with unified schema inference (the new default behavior)
-  result <- pro_request_jsonl_parquet(
+  result <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = input_jsonl,
     output = output_parquet,
     overwrite = TRUE,
     verbose = FALSE,
-  )
+  ))
 
   expect_true(dir.exists(output_parquet))
 
@@ -82,12 +82,12 @@ test_that("schema harmonization handles struct with different fields across file
   output_parquet <- file.path(tempdir(), "struct_fields_parquet")
   if (dir.exists(output_parquet)) unlink(output_parquet, recursive = TRUE)
 
-  result <- pro_request_jsonl_parquet(
+  result <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = input_jsonl,
     output = output_parquet,
     overwrite = TRUE,
     verbose = FALSE,
-  )
+  ))
 
   # Reading should not error - unified schema should include all fields
   expect_no_error({
@@ -131,12 +131,12 @@ test_that("schema harmonization handles null vs struct conflicts", {
   output_parquet <- file.path(tempdir(), "null_struct_parquet")
   if (dir.exists(output_parquet)) unlink(output_parquet, recursive = TRUE)
 
-  result <- pro_request_jsonl_parquet(
+  result <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = input_jsonl,
     output = output_parquet,
     overwrite = TRUE,
     verbose = FALSE,
-  )
+  ))
 
   expect_no_error({
     ds <- arrow::open_dataset(output_parquet)
@@ -178,12 +178,12 @@ test_that("schema harmonization handles nested struct variations", {
   output_parquet <- file.path(tempdir(), "nested_struct_parquet")
   if (dir.exists(output_parquet)) unlink(output_parquet, recursive = TRUE)
 
-  result <- pro_request_jsonl_parquet(
+  result <- suppressWarnings(pro_request_jsonl_parquet(
     input_jsonl = input_jsonl,
     output = output_parquet,
     overwrite = TRUE,
     verbose = FALSE,
-  )
+  ))
 
   expect_no_error({
     ds <- arrow::open_dataset(output_parquet)

--- a/tests/testthat/test-019-coverage_extras.R
+++ b/tests/testthat/test-019-coverage_extras.R
@@ -1,0 +1,131 @@
+# Tests targeting previously uncovered code paths in:
+#   - oas_binary.R
+#   - pro_validate_credentials.R
+#   - prepare_snapshot.R
+#   - sample_parquet_n.R
+
+# --- oas_binary -------------------------------------------------------------
+
+test_that("find_oas_binary uses explicit oas_bin when valid", {
+  fake <- tempfile()
+  file.create(fake)
+  on.exit(unlink(fake), add = TRUE)
+  expect_identical(find_oas_binary(fake), fake)
+})
+
+test_that("find_oas_binary uses package option as fallback", {
+  fake <- tempfile()
+  file.create(fake)
+  withr::local_options(openalexPro.oas_bin = fake)
+  on.exit(unlink(fake), add = TRUE)
+  expect_identical(find_oas_binary(), fake)
+})
+
+test_that("find_oas_binary aborts with a helpful message when nothing resolves", {
+  withr::local_options(openalexPro.oas_bin = NULL)
+  withr::local_envvar(PATH = "")
+  expect_error(find_oas_binary(oas_bin = NULL), "openalex-snapshot")
+})
+
+test_that("run_oas aborts when the binary exits non-zero", {
+  # /usr/bin/false (or `false`) exits 1 on every platform we run CI on
+  false_bin <- Sys.which("false")
+  skip_if(false_bin == "", "`false` binary not available")
+  expect_error(
+    run_oas(args = character(), oas_bin = unname(false_bin)),
+    "failed"
+  )
+})
+
+# --- pro_validate_credentials ----------------------------------------------
+
+test_that("pro_validate_credentials returns FALSE for an empty key", {
+  # NULL key: pro_rate_limit_status() returns FALSE without making an API call.
+  expect_message(
+    res <- pro_validate_credentials(api_key = NULL),
+    "Testing:"
+  )
+  expect_false(res)
+})
+
+test_that("pro_validate_credentials with show_credentials prints the key", {
+  expect_message(
+    pro_validate_credentials(api_key = "abc123", show_credentials = TRUE),
+    "abc123"
+  )
+})
+
+# --- prepare_snapshot -------------------------------------------------------
+
+test_that("prepare_snapshot copies the Makefile to a target directory", {
+  dest <- tempfile("prep_snap_")
+  on.exit(unlink(dest, recursive = TRUE, force = TRUE), add = TRUE)
+
+  suppressMessages({
+    out <- prepare_snapshot(path = dest)
+  })
+
+  expect_true(file.exists(out))
+  expect_identical(basename(out), "Makefile")
+})
+
+test_that("prepare_snapshot does not overwrite without overwrite = TRUE", {
+  dest <- tempfile("prep_snap_no_ow_")
+  dir.create(dest)
+  on.exit(unlink(dest, recursive = TRUE, force = TRUE), add = TRUE)
+
+  suppressMessages(prepare_snapshot(path = dest))
+
+  makefile <- file.path(dest, "Makefile")
+  writeLines("# sentinel", makefile)
+  suppressMessages(prepare_snapshot(path = dest, overwrite = FALSE))
+  expect_identical(readLines(makefile, n = 1L), "# sentinel")
+
+  suppressMessages(prepare_snapshot(path = dest, overwrite = TRUE))
+  expect_false(identical(readLines(makefile, n = 1L), "# sentinel"))
+})
+
+# --- sample_parquet_n ------------------------------------------------------
+
+test_that("sample_parquet_n validates its inputs", {
+  expect_error(sample_parquet_n(path = NA_character_, n = 5),
+               "non-missing character scalar")
+  expect_error(sample_parquet_n(path = "x", n = NA),
+               "non-missing numeric")
+  expect_error(sample_parquet_n(path = "x", n = 0),
+               "positive integer")
+  expect_error(sample_parquet_n(path = "x", n = 5, seed = NA),
+               "non-missing numeric")
+  expect_error(sample_parquet_n(path = "x", n = 5, select = character()),
+               "non-empty character vector")
+})
+
+test_that("sample_parquet_n samples from a temporary parquet file", {
+  skip_if_not_installed("arrow")
+  pq <- tempfile(fileext = ".parquet")
+  on.exit(unlink(pq), add = TRUE)
+  arrow::write_parquet(data.frame(id = 1:50, x = letters[1:50 %% 26 + 1]), pq)
+
+  res <- sample_parquet_n(path = pq, n = 10L, seed = 42L)
+  expect_s3_class(res, "data.frame")
+  expect_lte(nrow(res), 10L)
+  expect_setequal(names(res), c("id", "x"))
+
+  sub <- sample_parquet_n(path = pq, n = 5L, seed = 1L, select = "id")
+  expect_identical(names(sub), "id")
+})
+
+test_that("sample_parquet_n reuses a supplied DBI connection", {
+  skip_if_not_installed("arrow")
+  pq <- tempfile(fileext = ".parquet")
+  on.exit(unlink(pq), add = TRUE)
+  arrow::write_parquet(data.frame(id = 1:20), pq)
+
+  con <- DBI::dbConnect(duckdb::duckdb())
+  on.exit(DBI::dbDisconnect(con, shutdown = TRUE), add = TRUE)
+
+  res <- sample_parquet_n(path = pq, n = 5L, con = con)
+  expect_s3_class(res, "data.frame")
+  # connection should still be usable
+  expect_true(DBI::dbIsValid(con))
+})


### PR DESCRIPTION
## Summary

Release v0.10.4. Consolidates the development NEWS section into the 0.10.4 release. Highlights since 0.10.3:

- **New features**: `pro_request_parquet()` gains a `schema` parameter using bundled per-entity baseline schemas; new `oa_cache_schema()` helper.
- **Bug fixes**: robust handling of `abstract_inverted_index` across `STRUCT`/`MAP`/`VARCHAR` shapes; `pro_request_parquet()` pins the inferred type to `MAP(VARCHAR, BIGINT[])`.
- **Breaking**: `snapshot_to_parquet()`, `build_corpus_index()`, `lookup_by_id()` (and `_R` variants) moved to the `openalexSnapshot` package.
- **Internal / code quality** (this PR): `pro_request_parquet()` refactored to drop cyclomatic complexity below the `goodpractice` threshold; coverage raised from ~73% to ~80%; `.lintr` added with `line_length_linter(100)`; deprecated-call warnings silenced in their own tests.

See `NEWS.md` for the full list.

## Test plan

- [x] CI green on `dev` after merging PR #66.
- [x] `devtools::test()` clean locally.
- [ ] R CMD check on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)