### PR TITLE
chore: add lifecycle/license/codecov badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ format: gfm
 [![name status badge](https://openalexpro.r-universe.dev/badges/:name)](https://openalexpro.r-universe.dev/)
 [![openalexPro status badge](https://openalexpro.r-universe.dev/openalexPro/badges/version)](https://openalexpro.r-universe.dev/openalexPro)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.17453180.svg)](https://doi.org/10.5281/zenodo.17453180)
-[![Codecov test coverage](https://codecov.io/gh/openalexPro/openalexPro/graph/badge.svg)](https://app.codecov.io/gh/openalexPro/openalexPro)
+[![Lifecycle: maturing](https://img.shields.io/badge/lifecycle-maturing-blue.svg)](https://lifecycle.r-lib.org/articles/stages.html)
+[![License: GPL-2+](https://img.shields.io/badge/License-GPL%20%3E%3D%202-blue.svg)](https://www.gnu.org/licenses/gpl-2.0)
+[![Codecov](https://codecov.io/gh/openalexPro/openalexPro/graph/badge.svg)](https://app.codecov.io/gh/openalexPro/openalexPro)
 
 # Disclaimer
 


### PR DESCRIPTION
Adds lifecycle (maturing), license, and Codecov coverage badges to README.